### PR TITLE
Tools for adding certificates into xblconfig DTB

### DIFF
--- a/uefi_capsule_generation/BinToHex.py
+++ b/uefi_capsule_generation/BinToHex.py
@@ -1,4 +1,6 @@
-def bin_to_hex(input_file, output_file):
+import sys
+
+def bin_to_hex(input_file, output_file, add_prefix=False):
     try:
         with open(input_file, 'rb') as f:
             binary_data = f.read()
@@ -16,6 +18,9 @@ def bin_to_hex(input_file, output_file):
         hex_chunk = ''.join(f'{byte:02x}' for byte in chunk)
         hex_chunks.append(hex_chunk.zfill(8))  # Ensure each chunk is 8 hex digits
 
+    if add_prefix:
+        hex_chunks = [f"0x{chunk}" for chunk in hex_chunks]
+
     try:
         with open(output_file, 'w') as f:
             f.write(' '.join(hex_chunks))
@@ -25,9 +30,17 @@ def bin_to_hex(input_file, output_file):
 
     print(f"Conversion successful! Hex data with header written to {output_file}")
 
+
 if __name__ == "__main__":
-    import sys
-    if len(sys.argv) != 3:
-        print("Usage: python bin_to_hex.py <input_file> <output_file>")
+    args = sys.argv[1:]
+    add_prefix = False
+
+    if "-x" in args:
+        add_prefix = True
+        args.remove("-x")
+
+    if len(args) != 2:
+        print("Usage: python bin_to_hex.py [-x] <input_file> <output_file>")
     else:
-        bin_to_hex(sys.argv[1], sys.argv[2])
+        input_file, output_file = args
+        bin_to_hex(input_file, output_file, add_prefix)

--- a/uefi_capsule_generation/dump_dtb_xblconfig.py
+++ b/uefi_capsule_generation/dump_dtb_xblconfig.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+import argparse
+import hashlib
+import magic
+import struct
+import sys
+
+from elftools.elf.elffile import ELFFile
+
+# used by libmagic for DTB file detection
+DTB_MAGICS = { 0xd00dfeed, 0xedfe0dd0, 0xedfe0dd0, 0xedfe0dd0 }
+
+def is_device_tree_blob(data: bytes) -> bool:
+    if len(data) < 4:
+        return False
+    magic = int.from_bytes(data[:4], byteorder="big")
+    return magic in DTB_MAGICS
+
+def parse_elf(filename, dump_dtb=False):
+    with open(filename, 'rb') as f:
+        elf = ELFFile(f)
+
+        print("ELF Header:")
+        print(f"  Class: {elf.elfclass}-bit")
+        print(f"  Data encoding: {elf.little_endian and 'Little endian' or 'Big endian'}")
+        print(f"  Entry point: 0x{elf.header.e_entry:x}")
+        print(f"  Number of sections: {elf.num_sections()}")
+        print(f"  Number of program headers: {elf.num_segments()}")
+        print()
+
+        print("Program Headers:")
+        for i, segment in enumerate(elf.iter_segments()):
+            print(f"  Segment #{i}")
+            print(f"    Type: {segment['p_type']}")
+            print(f"    File Offset: 0x{segment['p_offset']:x}")
+            print(f"    Virtual Address: 0x{segment['p_vaddr']:x}")
+            print(f"    File Size: {segment['p_filesz']} bytes")
+            print(f"    Memory Size: {segment['p_memsz']} bytes")
+
+            if segment['p_filesz'] > 0:
+                data = segment.data()
+                if data:
+                    try:
+                        m = magic.Magic(mime=False)
+                        filetype = m.from_buffer(data)
+                        print(f"    Detected content type: {filetype}")
+
+                        if dump_dtb and is_device_tree_blob(data):
+                            outname = f"{filename}.segment{i}.dtb"
+                            with open(outname, "wb") as out:
+                                out.write(data)
+                            print(f"    >>> Extracted Device Tree Blob to {outname}")
+                    except Exception as e:
+                        print(f"    [!] Could not detect file type: {e}")
+            print()
+
+def replace_dtb(filename, segment_index, new_dtb_file, output_file):
+    with open(filename, "rb") as f:
+        orig_data = bytearray(f.read())
+        elf = ELFFile(f)
+        segments = list(elf.iter_segments())
+        segment = segments[segment_index]
+
+        phoff   = elf.header['e_phoff']
+        phentsz = elf.header['e_phentsize']
+        shoff   = elf.header['e_shoff']
+        is_64   = elf.elfclass == 64
+        endian  = "<" if elf.little_endian else ">"
+
+        # Load old and new DTB
+        old_dtb = segment.data()
+        with open(new_dtb_file, "rb") as nf:
+            new_dtb = nf.read()
+
+        offset = segment['p_offset']
+        old_size = segment['p_filesz']
+        new_size = len(new_dtb)
+        grow_size = new_size - old_size
+
+        print(f"[i] Replacing segment #{segment_index}: old size {old_size}, new size {new_size}")
+
+        # Compute SHA-384 hashes
+        old_hash = hashlib.sha384(old_dtb).digest()
+        new_hash = hashlib.sha384(new_dtb).digest()
+        print(f"[i] Old DTB SHA-384: {old_hash.hex()}")
+        print(f"[i] New DTB SHA-384: {new_hash.hex()}")
+
+        # Replace DTB in file
+        if grow_size <= 0:
+            orig_data[offset:offset+new_size] = new_dtb
+            if new_size < old_size:
+                orig_data[offset+new_size:offset+old_size] = b"\x00" * (old_size-new_size)
+        else:
+            # Grow file safely
+            tail = orig_data[offset+old_size:]
+            orig_data[offset:offset+new_size] = new_dtb
+            orig_data[offset+new_size:] = tail
+            orig_data.extend(b"\x00" * grow_size)
+
+            # Fix offsets in later program headers
+            for i, seg in enumerate(segments):
+                if seg['p_offset'] > offset:
+                    ph_offset = phoff + i * phentsz
+                    if is_64:
+                        orig_data[ph_offset + 0x08:ph_offset + 0x10] = struct.pack(endian + "Q", 
+                                                                                   seg['p_offset'] +
+                                                                                   grow_size)
+                    else:
+                        orig_data[ph_offset + 0x04:ph_offset + 0x08] = struct.pack(endian+"I", 
+                                                                                   seg['p_offset'] +
+                                                                                   grow_size)
+
+            # Fix offsets in later section headers
+            for i, sec in enumerate(elf.iter_sections()):
+                if sec['sh_offset'] > offset:
+                    sh_offset = shoff + i * elf.header['e_shentsize']
+                    if is_64:
+                        orig_data[sh_offset+0x18:sh_offset+0x20] = struct.pack(endian+"Q",
+                                                                               sec['sh_offset'] +
+                                                                               grow_size)
+                    else:
+                        orig_data[sh_offset+0x10:sh_offset+0x14] = struct.pack(endian+"I",
+                                                                               sec['sh_offset'] +
+                                                                               grow_size)
+
+        # Update p_filesz & p_memsz
+        ph_offset = phoff + segment_index * phentsz
+        if is_64:
+            orig_data[ph_offset+0x20:ph_offset+0x28] = struct.pack(endian+"Q", new_size)
+            orig_data[ph_offset+0x28:ph_offset+0x30] = struct.pack(endian+"Q", new_size)
+        else:
+            orig_data[ph_offset+0x10:ph_offset+0x14] = struct.pack(endian+"I", new_size)
+            orig_data[ph_offset+0x14:ph_offset+0x18] = struct.pack(endian+"I", new_size)
+
+        # Replace old hash with new hash. We really don't care about where exactly it's stored,
+        # we just look for the old value in binary form and replace it
+        pos = bytes(orig_data).find(old_hash)
+        if pos != -1:
+            print(f"[i] Found old DTB hash at offset 0x{pos:x}, replacing with new hash")
+            orig_data[pos:pos+len(new_hash)] = new_hash
+        else:
+            print("[!] Old DTB hash not found in ELF binary")
+
+        # Replace old dtb size. Same search approach as we do for the hash
+        old_size_le = struct.pack("<I", old_size)
+        new_size_le = struct.pack("<I", new_size)
+
+        replaced = 0
+        i = 0
+        while True:
+            pos = bytes(orig_data).find(old_size_le, i)
+            if pos == -1:
+                break
+            orig_data[pos:pos+4] = new_size_le
+            print(f"[i] Replaced old DTB size (LE) at 0x{pos:x}")
+            replaced += 1
+            i = pos + 4
+
+        if replaced == 0:
+            print("[!] No stored DTB size value found")
+        else:
+            print(f"[+] Updated {replaced} DTB size occurrence(s)")
+
+    with open(output_file, "wb") as out:
+        out.write(orig_data)
+
+    print(f"[+] Replaced DTB in segment #{segment_index}, written new ELF: {output_file}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="ELF parser with DTB replace")
+    parser.add_argument("elf_file", help="Path to ELF binary")
+    parser.add_argument("--dump-dtb", action="store_true",
+                        help="Extract DTB blobs from program headers into separate files")
+    parser.add_argument("--replace-dtb", nargs=3, metavar=("SEG_INDEX", "NEW_DTB", "OUTPUT_ELF"),
+                        help="Replace DTB in segment SEG_INDEX with NEW_DTB, save to OUTPUT_ELF")
+    args = parser.parse_args()
+
+    if args.replace_dtb:
+        seg_index, new_dtb, output_elf = args.replace_dtb
+        replace_dtb(args.elf_file, int(seg_index), new_dtb, output_elf)
+    else:
+        parse_elf(args.elf_file, dump_dtb=args.dump_dtb)

--- a/uefi_capsule_generation/set_dtb_property.py
+++ b/uefi_capsule_generation/set_dtb_property.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+
+import libfdt
+import re
+import struct
+import sys
+
+from pathlib import Path
+
+def encode_value(value: str) -> bytes:
+    """
+    Encode a value for FDT:
+    - @file:<path>  -> binary split into 32-bit big-endian words
+    - @list:<path>  -> text file with hex/decimal ints, each -> 32-bit word
+    - single integer -> 4-byte big-endian
+    - list of integers -> array of 4-byte big-endian
+    - otherwise -> UTF-8 string
+    """
+    value = value.strip()
+
+    # Binary from file -> 32-bit words
+    if value.startswith("@file:"):
+        file_path = value[6:]
+        with open(file_path, "rb") as f:
+            data = f.read()
+        if len(data) % 4 != 0:
+            data += b'\x00' * (4 - (len(data) % 4))
+        return b''.join(struct.pack(">I", struct.unpack(">I", data[i:i+4])[0])
+                        for i in range(0, len(data), 4))
+
+    # Integer list from file
+    if value.startswith("@list:"):
+        file_path = value[6:]
+        with open(file_path, "r") as f:
+            text = f.read()
+        # Split on whitespace or commas
+        parts = re.split(r'[\s,]+', text.strip())
+        return b''.join(struct.pack(">I", int(p, 0)) for p in parts if p)
+
+    # Single integer
+    int_pattern = re.compile(r'^-?(0x[0-9a-fA-F]+|\d+)$')
+    int_list_pattern = re.compile(r'^(-?(0x[0-9a-fA-F]+|\d+)[ ,]+)+(-?(0x[0-9a-fA-F]+|\d+))$')
+
+    if int_pattern.match(value):
+        return struct.pack('>I', int(value, 0))
+    elif int_list_pattern.match(value + " "):
+        parts = re.split(r'[ ,]+', value.strip())
+        return b''.join(struct.pack('>I', int(p, 0)) for p in parts if p)
+    else:
+        # Default: UTF-8 string
+        return value.encode('utf-8')
+
+def set_dtb_property(dtb_path: str, node_path: str, prop_name: str, value: str,
+                     out_path: str, extra_space: int = 1024):
+    """
+    Set or add a property in a DTB, automatically resizing if needed.
+    """
+    # Load DTB from file
+    with open(dtb_path, "rb") as f:
+        dtb_data = f.read()
+
+    fdt_obj = libfdt.Fdt(dtb_data)
+
+    try:
+        node_off = fdt_obj.path_offset(node_path)
+    except libfdt.FdtException:
+        raise ValueError(f"Node path '{node_path}' not found in DTB")
+
+    value_bytes = encode_value(value)
+
+    try:
+        fdt_obj.setprop(node_off, prop_name, value_bytes)
+    except libfdt.FdtException as e:
+        # Handle not enough space error
+        if hasattr(e, "err") and e.err == -libfdt.FDT_ERR_NOSPACE:
+            print("[!] Not enough space, resizing DTB...")
+            # Resize DTB buffer to fit new property
+            fdt_obj.resize(len(fdt_obj.as_bytearray()) + max(len(value_bytes), extra_space)) 
+            # Retry setting the property
+            fdt_obj.setprop(node_off, prop_name, value_bytes)
+        else:
+            raise
+
+    # Save updated DTB
+    with open(out_path, "wb") as f:
+        f.write(fdt_obj.as_bytearray())
+
+    print(f"[+] Updated '{prop_name}' at '{node_path}', written to {out_path}")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 6:
+        print(f"Usage: {sys.argv[0]} <input.dtb> <node_path> <property> <value|@file:path|@list:path> <output.dtb>")
+        sys.exit(1)
+
+    input_dtb, node_path, prop_name, value, output_dtb = sys.argv[1:]
+    set_dtb_property(input_dtb, node_path, prop_name, value, output_dtb)


### PR DESCRIPTION
Add tools for ELF parsing, extracting DTBs from program headers (based on detection using libmagic), modifying the properties in these DTB files and swapping the old DTB with the new one.

This allows to add a certificate to "/sw/uefi/uefiplat/QcCapsuleRootCert" node in xbl_config.elf DTB avoiding QDTE tool usage.

Usage example:

Generate hex dump of the root cert (use -x flag):
```
$ python3 BinToHex.py -x QcFMPRoot.cer QcFMPRoot.inc
$ cat QcFMPRoot.inc
0x00000401 0x308203fd 0x308202e5 0xa0030201 ...
```
Dump all dtbs from xbl_config.elf:
```
$ python3 dump_dtb_xblconfig.py ./xbl_config.elf --dump-dtb
...
  Segment #7
    Type: PT_LOAD
    File Offset: 0x34408
    Virtual Address: 0x14904198
    File Size: 14836 bytes
    Memory Size: 14836 bytes
    Detected content type: Device Tree Blob version 17, size=14835,
      boot CPU=0, string block size=2351, DT structure block size=12428
    >>> Extracted Device Tree Blob to ./xbl_config.elf.segment7.dtb

  Segment #8
    Type: PT_LOAD
    File Offset: 0x37dfc
    Virtual Address: 0x14907b8c
    File Size: 91772 bytes
    Memory Size: 91772 bytes
    Detected content type: Device Tree Blob version 17, size=91772,
      boot CPU=0, string block size=10947, DT structure block size=79800
    >>> Extracted Device Tree Blob to ./xbl_config.elf.segment8.dtb
...
```
Check previous value stored in QcCapsuleRootCert property:
```
$ fdtdump xbl_config.elf.segment8.dtb > xbl_config_modified.txt;
$ cat xbl_config_modified.txt | grep QcCapsuleRoot

  QcCapsuleRootCert = <0x000003c2 0x308203be 0x308202a6 ...
```
Write new cert value:
```
$ python3 set_dtb_property.py xbl_config.elf.segment8.dtb \
  /sw/uefi/uefiplat QcCapsuleRootCert @list:QcFMPRoot.inc \
  xbl_config.elf.segment8_new.dtb

  Not enough space, resizing DTB...
  Updated 'QcCapsuleRootCert' at '/sw/uefi/uefiplat', written to
    xbl_config.elf.segment8_new.dtb
```
Check new value stored in QcCapsuleRootCert property:
```
$ fdtdump xbl_config.elf.segment8_new.dtb > xbl_config_modified.txt
$ cat xbl_config_modified.txt | grep QcCapsuleRoot

  QcCapsuleRootCert = <0x00000401 0x308203fd 0x308202e5
```
Re-place DTB in ELF binary, extending segments if needed:
```
$ python3 dump_dtb_xblconfig.py ./xbl_config.elf --replace-dtb 8 \
  xbl_config.elf.segment8_new.dtb ./xbl_config_patched.elf
[i] Replacing segment #8: old size 90740, new size 90868
[i] Old DTB SHA-384: 3bcdd649064f9b0c264bc1c8a6951e985f0482d11...
[i] New DTB SHA-384: acb507554f9c754c72a582024a5921aaee735f870...
[i] Found old DTB hash at offset 0x4f2a8, replacing with new hash
[i] Replaced old DTB size (LE) at 0x3d4
[+] Updated 1 DTB size occurrence(s)
[+] Replaced DTB in segment #8, written new ELF: ./xbl_config_patched.elf
```
When the DTB is replaced in xbl_config.elf, the hash in the hash table segment is recalculated, and the size of DTB in the XBL config metadata is updated.

Both the hash value and size value are simply searched for in the binary and replaced, so the script sources doesn't expose any information about the format of the hash table segment or any metadata structure of the
xblconfig binary.