### PR TITLE
uefi_capsule: fix hex parsing in set_dtb_property.py for @list param

### DIFF
--- a/uefi_capsule_generation/set_dtb_property.py
+++ b/uefi_capsule_generation/set_dtb_property.py
@@ -37,7 +37,7 @@ def encode_value(value: str) -> bytes:
             text = f.read()
         # Split on whitespace or commas
         parts = re.split(r'[\s,]+', text.strip())
-        return b''.join(struct.pack(">I", int(p, 0)) for p in parts if p)
+        return b''.join(struct.pack(">I", int(p, 16)) for p in parts if p)
 
     # Single integer
     int_pattern = re.compile(r'^-?(0x[0-9a-fA-F]+|\d+)$')


### PR DESCRIPTION
BinToHex.py outputs hex values without the 0x prefix (e.g., 000003a6), but set_dtb_property.py was trying to parse them with int(p, 0), which assumes decimal when no prefix is present, causing the error since hex digits like 'a' are invalid in decimal.

Change int(p, 0) to int(p, 16) since BinToHex.py outputs hex without 0x prefix.