### PR TITLE
uefi_capsule: add --edk2-path and --ptool-path options to use local checkouts

### DIFF
--- a/uefi_capsule_generation/FVCreation.py
+++ b/uefi_capsule_generation/FVCreation.py
@@ -247,17 +247,18 @@ def generate_fv_main_file(lsFFsFiles):
         return False
 
 
-def generate_fv(s_output_file_name, ls_ffs, s_gen_fv):
+def generate_fv(s_output_file_name, ls_ffs, s_gen_fv, tools_dir=None):
     bReturn = False
     if not generate_fv_main_file(ls_ffs):
         print(f"ERROR: Failure creating {FV_MAIN_INF_NAME} file.")
         return False
-    
+
     if platform.system() == "Linux":
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        sFVCommand = f"{dir_path}/GenFv -o {s_output_file_name} -i {FV_MAIN_INF_NAME} -v"
+        if tools_dir is None:
+            tools_dir = os.path.dirname(os.path.realpath(__file__))
+        sFVCommand = f"{tools_dir}/GenFv -o {s_output_file_name} -i {FV_MAIN_INF_NAME} -v"
         execute_command_linux(sFVCommand)
-    
+
     if platform.system() == "Windows":
         sFVCommand = f"{s_gen_fv} -o {s_output_file_name} -i {FV_MAIN_INF_NAME} -v"
         execute_command(sFVCommand)
@@ -434,7 +435,8 @@ def process_sys_fw_ffs_creation(
         fw_ver_binary_data,
         ls_ffs,
         ls_paths,
-        g_dynamic_var
+        g_dynamic_var,
+        tools_dir=None
     ):
     try:
         #
@@ -490,7 +492,7 @@ def process_sys_fw_ffs_creation(
         #
         # Generate FFS file of each input binary
         #
-        if not generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var):
+        if not generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var, tools_dir):
             print("ERROR: Error Generating FFS files.")
             return False
         elif print_logs >= 2:
@@ -502,7 +504,7 @@ def process_sys_fw_ffs_creation(
     return True
 
 
-def generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var):
+def generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var, tools_dir=None):
     
     try:
         for raw_fwentry in g_dynamic_var.XmlRawFwEntryList:
@@ -530,10 +532,11 @@ def generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var):
             # execute GenFfs in Linux
             #
             if platform.system() == "Linux":
-                dir_path = os.path.dirname(os.path.realpath(__file__))
+                if tools_dir is None:
+                    tools_dir = os.path.dirname(os.path.realpath(__file__))
                 raw_fwentry_FileGuid_uuid_bytes_obj = bytes(raw_fwentry.FileGuid)
                 raw_fwentry_FileGuid_uuid_str = str(uuid.UUID(bytes=raw_fwentry_FileGuid_uuid_bytes_obj))
-                s_command = f"{dir_path}/GenFfs -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {raw_fwentry_FileGuid_uuid_str} -s -v -i {os.path.join(s_dir_path, raw_fwentry.InputBinary)}"
+                s_command = f"{tools_dir}/GenFfs -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {raw_fwentry_FileGuid_uuid_str} -s -v -i {os.path.join(s_dir_path, raw_fwentry.InputBinary)}"
                 execute_command_linux(s_command)
 
             #
@@ -552,8 +555,9 @@ def generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var):
 
         print(f"INFO: Creating ffs file for {SYS_FW_METADATA_FILE}.")
         if platform.system() == "Linux":
-            dir_path = os.path.dirname(os.path.realpath(__file__))
-            s_command = f"{dir_path}/GenFfs -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {s_guid} -s -v -i {SYS_FW_METADATA_FILE}"
+            if tools_dir is None:
+                tools_dir = os.path.dirname(os.path.realpath(__file__))
+            s_command = f"{tools_dir}/GenFfs -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {s_guid} -s -v -i {SYS_FW_METADATA_FILE}"
             execute_command_linux(s_command)
 
         if platform.system() == "Windows":
@@ -628,16 +632,30 @@ class Arguments:
 def The_Main(args):
 
     s_breaking_change_number = "0"
-    ls_ffs = []  
-    ls_paths = []  
+    ls_ffs = []
+    ls_paths = []
     g_dynamic_var = FVC_h.GlobalDynamicVariable()
     fw_ver_binary_data = FVC_h.QSYS_FW_VERSION_DATA()
     fw_version = 0
     lowest_supported_fw_version = 0
     s_gen_ffs = "GenFfs.exe"
-    s_gen_fv = "GenFv.exe" 
+    s_gen_fv = "GenFv.exe"
+    tools_dir = None
+
+    # Extract --edk2-path if provided; derive tools_dir from it
+    args = list(args)
+    for i, arg in enumerate(args):
+        if arg in ('--edk2-path', '-edk2path') and i + 1 < len(args):
+            edk2_path = args[i + 1]
+            if platform.system() == "Linux":
+                tools_dir = os.path.join(edk2_path, 'BaseTools', 'Source', 'C', 'bin')
+            elif platform.system() == "Windows":
+                tools_dir = edk2_path
+            del args[i:i + 2]
+            break
+
     # fv_type = FV_TYPE.UNKNOWN
-    
+
     # Skipping the re-creation of all executables
     if len(args) == 1 and args[0].lower() == "-v":
         print("Version: %s" % (TOOL_VERSION_STRING))
@@ -660,18 +678,19 @@ def The_Main(args):
         for i in range(5, len(args)):
             ls_paths.append(args[i])
         
-        r = process_sys_fw_ffs_creation(s_xml_file_name=s_xml_file_name, 
-                                        s_fw_ver_binary_file=s_fw_ver_binary_file, 
-                                        s_gen_ffs= "GenFfs.exe",
-                                        s_breaking_change_number=s_breaking_change_number, 
-                                        fw_ver_binary_data=fw_ver_binary_data, 
-                                        ls_ffs=ls_ffs, 
-                                        ls_paths=ls_paths, 
-                                        g_dynamic_var=g_dynamic_var)
+        r = process_sys_fw_ffs_creation(s_xml_file_name=s_xml_file_name,
+                                        s_fw_ver_binary_file=s_fw_ver_binary_file,
+                                        s_gen_ffs=s_gen_ffs,
+                                        s_breaking_change_number=s_breaking_change_number,
+                                        fw_ver_binary_data=fw_ver_binary_data,
+                                        ls_ffs=ls_ffs,
+                                        ls_paths=ls_paths,
+                                        g_dynamic_var=g_dynamic_var,
+                                        tools_dir=tools_dir)
         if not r:
             print("process_sys_fw_ffs_creation failed")
     
-    if not generate_fv(s_output_file_name, ls_ffs, s_gen_fv):
+    if not generate_fv(s_output_file_name, ls_ffs, s_gen_fv, tools_dir):
         print("GenerateFV failed.\n")
         return
     else:

--- a/uefi_capsule_generation/README.md
+++ b/uefi_capsule_generation/README.md
@@ -121,6 +121,13 @@ git clone https://github.com/quic/cbsp-boot-utilities.git
    python3 capsule_setup.py
    ```
 
+   This clones edk2, builds `GenFfs`/`GenFv`, and downloads
+   `GenerateCapsule.py` alongside the scripts.
+
+   If you already have a local edk2 build, you can skip this step and
+   pass `--edk2-path <dir>` to `FVCreation.py` / `capsule_creator.py`
+   instead (see steps 4 and 5).
+
 1. **Generate Firmware Version bin File:**
 
    ```sh
@@ -159,6 +166,8 @@ git clone https://github.com/quic/cbsp-boot-utilities.git
    - `-T <Target>`: Target platform, `QCS6490`, `QCS9100`, `QCS8300`,
      or `QCS615`.
    - `-F <partition.conf>`: Path to a local `partition.conf` file.
+   - `--ptool-path <dir>`: Path to an existing `qcom-ptool` checkout.
+     When provided, the repository is not cloned from GitHub.
 
    Once `FvUpdate.xml` is generated, update the `Operation` field for
    each firmware entry as needed. By default the operation is set to
@@ -179,10 +188,14 @@ git clone https://github.com/quic/cbsp-boot-utilities.git
 
    - `firmware.fv`: The firmware volume file.
    - `-FvType`: Type of firmware volume.
-   - `FvUpdate_UFS.xml`: XML file for firmware update.
+   - `FvUpdate.xml`: XML file for firmware update.
    - `SYSFW_VERSION.bin`: The firmware version file generated in the
      previous step.
    - `Images/`: Directory containing the images.
+   - `--edk2-path <dir>`: Path to an existing edk2 directory with built
+     `GenFfs`/`GenFv` tools. When provided, `capsule_setup.py` does not
+     need to be run. On Linux the binaries are resolved from
+     `<dir>/BaseTools/Source/C/bin/`.
 
 1. **Update JSON Parameters:**
 
@@ -263,3 +276,29 @@ python3 capsule_creator.py \
 
 The **-setup** parameter is optional and can be used for the initial setup.
 You can omit it in subsequent runs.
+
+If you have a local edk2 build and/or a local `qcom-ptool` checkout,
+you can skip the setup step entirely by providing their paths directly:
+
+```sh
+python3 capsule_creator.py \
+  -fwver 0.0.A.B \
+  -lfwver 0.0.0.0 \
+  -config config.json \
+  -p Certificates/QcFMPCert.pem \
+  -x Certificates/QcFMPRoot.pub.pem \
+  -oc Certificates/QcFMPSub.pub.pem \
+  -guid <ESRT GUID> \
+  -capsule <capsule_name>.cap \
+  -images /Images \
+  -S <StorageType> \
+  -T <Target> \
+  --edk2-path /path/to/edk2 \
+  --ptool-path /path/to/qcom-ptool
+```
+
+ - `--edk2-path <dir>`: Path to an existing edk2 directory with built
+   `GenFfs`/`GenFv` tools. `GenerateCapsule.py` and its `Common/`
+   dependency are also resolved from this tree.
+ - `--ptool-path <dir>`: Path to an existing `qcom-ptool` checkout.
+   When provided, the repository is not cloned from GitHub.

--- a/uefi_capsule_generation/UpdateFvXml.py
+++ b/uefi_capsule_generation/UpdateFvXml.py
@@ -12,6 +12,7 @@ import sys
 
 REPO_URL = "https://github.com/qualcomm-linux/qcom-ptool.git"
 REPO_DIR = "qcom-ptool"
+DEFAULT_REPO_DIR = REPO_DIR
 
 SUPPORTED_PLATFORMS = {
     "QCS6490": "qcs6490-rb3gen2",
@@ -25,10 +26,10 @@ def get_target_name(soc_name):
         if soc_name == platform:
             return target
 
-def safe_clone():
-    if not os.path.exists(REPO_DIR):
+def safe_clone(repo_dir):
+    if not os.path.exists(repo_dir):
         try:
-            subprocess.run(["git", "clone", REPO_URL], check=True)
+            subprocess.run(["git", "clone", REPO_URL, repo_dir], check=True)
         except subprocess.CalledProcessError as e:
             print(f"Error cloning repo: {e}")
             sys.exit(1)
@@ -167,7 +168,12 @@ def main():
     parser.add_argument('-T', metavar='TARGET', help='Target argument')
     parser.add_argument("-S", "--StorageType", choices=["UFS", "EMMC"], help="Specify storage type: UFS or EMMC")
     parser.add_argument('-F', metavar='PARTITIONS_CONF', help='Partitions config argument')
+    parser.add_argument('--ptool-path', dest='ptool_path', default=None,
+                        help='Path to an existing qcom-ptool directory; '
+                             'when provided, the repository is not cloned')
     args = parser.parse_args()
+
+    repo_dir = args.ptool_path if args.ptool_path else DEFAULT_REPO_DIR
 
     if args.F:
         if args.StorageType:
@@ -179,16 +185,17 @@ def main():
         partition_conf_path = args.F
         lines = read_partitions_conf(partition_conf_path)
         args.StorageType = detect_storage_type_from_conf(lines)
-    elif args.T :
+    elif args.T:
         if not args.StorageType:
             print("Error: You must provide -S/--StorageType when using -T/--target.")
             sys.exit(1)
-        safe_clone()
+        if not args.ptool_path:
+            safe_clone(repo_dir)
         target = get_target_name(args.T)
         if not target:
             print(f"Provided target is Unknown !!! Please re-check")
             sys.exit(1)
-        partition_conf_path = os.path.join(REPO_DIR, "platforms", target, "ufs", "partitions.conf")
+        partition_conf_path = os.path.join(repo_dir, "platforms", target, "ufs", "partitions.conf")
         lines = read_partitions_conf(partition_conf_path)
     else:
         print("Error: Invalid argument combination.")

--- a/uefi_capsule_generation/capsule_creator.py
+++ b/uefi_capsule_generation/capsule_creator.py
@@ -25,7 +25,8 @@ def main(args):
     run_command(f"python3 SYSFW_VERSION_program.py -Gen -FwVer {args.fwver} -LFwVer {args.lfwver} -O SYSFW_VERSION.bin")
 
     # Step 2: Create FvUpdate.xml
-    run_command(f'python3 UpdateFvXml.py -S {args.S} -T {args.t}')
+    ptool_path_arg = f'--ptool-path {args.ptool_path}' if args.ptool_path else ''
+    run_command(f'python3 UpdateFvXml.py -S {args.S} -T {args.t} {ptool_path_arg}')
 
     # Step 3: Create firmware volume
     edk2_path_arg = f'--edk2-path {args.edk2_path}' if args.edk2_path else ''
@@ -57,6 +58,9 @@ if __name__ == "__main__":
     parser.add_argument('--edk2-path', dest='edk2_path', default=None,
                         help='Path to an existing edk2 directory with built GenFfs/GenFv tools; '
                              'when provided, capsule_setup.py does not need to be run')
+    parser.add_argument('--ptool-path', dest='ptool_path', default=None,
+                        help='Path to an existing qcom-ptool directory; '
+                             'when provided, the repository is not cloned')
     parser.add_argument("-S", "--StorageType", choices=["UFS", "EMMC"], required=True, help="Specify storage type: UFS or EMMC")
     parser.add_argument("-T", "--target", required=True, help="Specify target platform (e.g., QCS6490)")
 

--- a/uefi_capsule_generation/capsule_creator.py
+++ b/uefi_capsule_generation/capsule_creator.py
@@ -23,18 +23,24 @@ def main(args):
         run_command("python3 capsule_setup.py", fail_on_error=True)
     # Step 1: Generate SYSFW_VERSION.bin
     run_command(f"python3 SYSFW_VERSION_program.py -Gen -FwVer {args.fwver} -LFwVer {args.lfwver} -O SYSFW_VERSION.bin")
-    
+
     # Step 2: Create FvUpdate.xml
     run_command(f'python3 UpdateFvXml.py -S {args.S} -T {args.t}')
-    
+
     # Step 3: Create firmware volume
-    run_command(f'python3 FVCreation.py firmware.fv "-FvType" "SYS_FW" "FvUpdate.xml" SYSFW_VERSION.bin {args.images}')
-    
+    edk2_path_arg = f'--edk2-path {args.edk2_path}' if args.edk2_path else ''
+    run_command(f'python3 FVCreation.py firmware.fv "-FvType" "SYS_FW" "FvUpdate.xml" SYSFW_VERSION.bin {args.images} {edk2_path_arg}')
+
     # Step 4: Update JSON parameters
     run_command(f'python3 UpdateJsonParameters.py -j {args.config} -f SYS_FW -b SYSFW_VERSION.bin -pf firmware.fv -p {args.p} -x {args.x} -oc {args.oc} -g {args.guid}')
     
     # Step 5: Generate capsule
-    run_command(f'python3 GenerateCapsule.py -e -j {args.config} -o {args.capsule} --capflag PersistAcrossReset -v')
+    if args.edk2_path:
+        generate_capsule = os.path.join(args.edk2_path, 'BaseTools', 'Source', 'Python', 'Capsule', 'GenerateCapsule.py')
+        pythonpath = os.path.join(args.edk2_path, 'BaseTools', 'Source', 'Python')
+        run_command(f'PYTHONPATH={pythonpath} python3 {generate_capsule} -e -j {args.config} -o {args.capsule} --capflag PersistAcrossReset -v')
+    else:
+        run_command(f'python3 GenerateCapsule.py -e -j {args.config} -o {args.capsule} --capflag PersistAcrossReset -v')
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Combined script for Capsule generation")
@@ -48,6 +54,9 @@ if __name__ == "__main__":
     parser.add_argument('-capsule', required=True, help='Output capsule file name')
     parser.add_argument('-images', required=True, help='Images directory')
     parser.add_argument('-setup', action='store_true', help='Run capsule setup script')
+    parser.add_argument('--edk2-path', dest='edk2_path', default=None,
+                        help='Path to an existing edk2 directory with built GenFfs/GenFv tools; '
+                             'when provided, capsule_setup.py does not need to be run')
     parser.add_argument("-S", "--StorageType", choices=["UFS", "EMMC"], required=True, help="Specify storage type: UFS or EMMC")
     parser.add_argument("-T", "--target", required=True, help="Specify target platform (e.g., QCS6490)")
 


### PR DESCRIPTION
Two new optional arguments allow users to skip the network-dependent setup step (capsule_setup.py) by pointing at locally available checkouts:

`--edk2-path <dir> `(FVCreation.py, capsule_creator.py): resolves GenFfs, GenFv, and GenerateCapsule.py directly from an existing edk2 build tree (BaseTools/Source/C/bin/ and BaseTools/Source/Python/) instead of copying them via capsule_setup.py. PYTHONPATH is set automatically so GenerateCapsule.py can find the Common/ module.

`--ptool-path <dir>` (UpdateFvXml.py, capsule_creator.py): uses an existing qcom-ptool checkout instead of cloning it from GitHub when -T/--target is used.

Both options are backward-compatible - when omitted, behaviour is unchanged.