### PR TITLE
uefi_capsule: apply linter fixes and code style cleanup

### DIFF
--- a/uefi_capsule_generation/BinToHex.py
+++ b/uefi_capsule_generation/BinToHex.py
@@ -1,6 +1,6 @@
 def bin_to_hex(input_file, output_file):
     try:
-        with open(input_file, 'rb') as f:
+        with open(input_file, "rb") as f:
             binary_data = f.read()
     except FileNotFoundError:
         print(f"Error: The file {input_file} was not found.")
@@ -8,25 +8,27 @@ def bin_to_hex(input_file, output_file):
 
     # Calculate the size of the binary file and create the 32-bit header
     file_size = len(binary_data)
-    header = f'{file_size:08x}'
+    header = f"{file_size:08x}"
 
     hex_chunks = [header]
     for i in range(0, len(binary_data), 4):
-        chunk = binary_data[i:i+4]
-        hex_chunk = ''.join(f'{byte:02x}' for byte in chunk)
+        chunk = binary_data[i : i + 4]
+        hex_chunk = "".join(f"{byte:02x}" for byte in chunk)
         hex_chunks.append(hex_chunk.zfill(8))  # Ensure each chunk is 8 hex digits
 
     try:
-        with open(output_file, 'w') as f:
-            f.write(' '.join(hex_chunks))
+        with open(output_file, "w") as f:
+            f.write(" ".join(hex_chunks))
     except IOError:
         print(f"Error: Could not write to file {output_file}.")
         return
 
     print(f"Conversion successful! Hex data with header written to {output_file}")
 
+
 if __name__ == "__main__":
     import sys
+
     if len(sys.argv) != 3:
         print("Usage: python bin_to_hex.py <input_file> <output_file>")
     else:

--- a/uefi_capsule_generation/FVCreation.py
+++ b/uefi_capsule_generation/FVCreation.py
@@ -4,21 +4,21 @@
 # --------------------------------------------------------------------
 
 
-import os
-from enum import Enum
-import FVCreation_header as FVC_h
-import subprocess
-import struct
 import binascii
-import sys
-import XmlParser as xp
-import XmlFwEntryValidation as XFEV
-import re
-import traceback
 import ctypes
+import os
 import platform
+import re
+import struct
+import subprocess
+import sys
+import traceback
 import uuid
+from enum import Enum
 
+import FVCreation_header as FVC_h
+import XmlFwEntryValidation as XFEV
+import XmlParser as xp
 
 print_logs = 0
 

--- a/uefi_capsule_generation/FVCreation.py
+++ b/uefi_capsule_generation/FVCreation.py
@@ -16,7 +16,6 @@ import XmlFwEntryValidation as XFEV
 import re
 import traceback
 import ctypes
-import pickle
 import platform
 import uuid
 
@@ -657,7 +656,7 @@ def generate_sys_fw_ffs_list(
                 print(f"ERROR: Failure locating {s_file} file to create FV.")
                 return False
 
-    except Exception as e:
+    except Exception:
         print(traceback.format_exc())
 
     return True

--- a/uefi_capsule_generation/FVCreation.py
+++ b/uefi_capsule_generation/FVCreation.py
@@ -236,7 +236,7 @@ def generate_fv_main_file(lsFFsFiles):
             for sFile in lsFFsFiles:
                 sw.write("EFI_FILE_NAME = " + sFile + "\n")
         return True
-    except:
+    except Exception:
         print(f"Error creating {FV_MAIN_INF_NAME} file.")
         return False
 

--- a/uefi_capsule_generation/FVCreation.py
+++ b/uefi_capsule_generation/FVCreation.py
@@ -1,4 +1,3 @@
-
 # --------------------------------------------------------------------
 # Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -22,7 +21,6 @@ import platform
 import uuid
 
 
-
 print_logs = 0
 
 EXECUTABLE_BLOCK_SIZE = 4096
@@ -30,7 +28,7 @@ FV_MAIN_INF_NAME = "FVMain.inf"
 TOOL_VERSION_STRING = "1.1"
 SYS_FW_METADATA_HEADER_SIGNATURE1 = 0x2E1946FB
 SYS_FW_METADATA_HEADER_SIGNATURE2 = 0x7F744D57
-FMP_PAYLOAD_HEADER_SIGNATURE = 0x3153534d
+FMP_PAYLOAD_HEADER_SIGNATURE = 0x3153534D
 SYS_FW_METADATA_HEADER_REVISION_V3 = 0x3
 SYS_FW_METADATA_FILE = "Metadata.dat"
 SYS_FW_VERSION_DATA_SIGNATURE = "SYSFWVER"
@@ -56,19 +54,19 @@ class QSYS_FW_VERSION_DATA(ctypes.Structure):
         ("LowestSupportedFwVersion", ctypes.c_uint),
     ]
 
-
     def to_bytes(self):
         try:
             return bytes(bytearray(self))
         except Exception as e:
             print(f"ERROR: Failure converting structure to byte array(error:{e})", e)
 
-
     @classmethod
     def from_bytes(cls, byte_arr):
         try:
             version_data = cls()
-            ctypes.memmove(ctypes.addressof(version_data), byte_arr, ctypes.sizeof(version_data))
+            ctypes.memmove(
+                ctypes.addressof(version_data), byte_arr, ctypes.sizeof(version_data)
+            )
             return version_data
 
         except Exception:
@@ -110,9 +108,9 @@ def get_exe_name(ls_files, s_pattern):
 
 def get_file_name_only(s_file):
     if "\\" in s_file:  # it is a relative path
-        return s_file[s_file.rfind("\\") + 1:s_file.rfind(".")]
+        return s_file[s_file.rfind("\\") + 1 : s_file.rfind(".")]
     else:  # just a file name, remove extension and return
-        return s_file[:s_file.rfind(".")]
+        return s_file[: s_file.rfind(".")]
 
 
 def Reflect(data_b, l_i):
@@ -122,15 +120,16 @@ def Reflect(data_b, l_i):
 
     for i in range(l_i):
         if (data_i & 0x1) != 0:
-            reff_i = reff_i | int(1 << (int(l_i-1) - i))
+            reff_i = reff_i | int(1 << (int(l_i - 1) - i))
         data_i = data_i >> 1
 
     return reff_i
 
+
 def CalcCRC32_i(buffer_b, l_i):
     k_i = 8
     MSB_i = 0
-    gx_h = 0x04c11DB7
+    gx_h = 0x04C11DB7
     regs_h = 0xFFFFFFFF
     regsMask_h = 0xFFFFFFFF
     regsMSB_i = 0
@@ -140,13 +139,12 @@ def CalcCRC32_i(buffer_b, l_i):
     regsMask_i = int(regsMask_h)
 
     for i in range(l_i):
-
         DataByte_b = buffer_b[i]
         DataByte_i = int(DataByte_b)
         DataByte_i = Reflect(DataByte_i, 8)
 
         for j in range(k_i):
-            MSB_i = DataByte_i >> (k_i-1)
+            MSB_i = DataByte_i >> (k_i - 1)
             MSB_i = MSB_i & 1
             regsMSB_i = int(regs_i >> 31) & 1
             regs_i = regs_i << 1
@@ -159,40 +157,37 @@ def CalcCRC32_i(buffer_b, l_i):
 
     return Reflect(regs_i, 32) ^ int(0xFFFFFFFF)
 
+
 def execute_command(s_command):
     try:
         result = subprocess.run(
-            ["cmd", "/c", s_command],
-            capture_output=True,
-            text=True,
-            shell=True
+            ["cmd", "/c", s_command], capture_output=True, text=True, shell=True
         )
         print(result.stdout)
         if result.stderr:
             print(result.stderr)
     except Exception as e:
         print(f"Exception running command: {e}\n")
-
 
 
 def execute_command_linux(s_command):
     try:
-        result = subprocess.run(
-            s_command,
-            capture_output=True,
-            text=True,
-            shell=True
-        )
+        result = subprocess.run(s_command, capture_output=True, text=True, shell=True)
         print(result.stdout)
         if result.stderr:
             print(result.stderr)
     except Exception as e:
         print(f"Exception running command: {e}\n")
 
+
 def regenerate_all_executables():
     ls_executables = []
     cur_directory = os.path.dirname(os.path.abspath(__file__))
-    resource_files = [f for f in os.listdir(cur_directory) if os.path.isfile(os.path.join(cur_directory, f))]
+    resource_files = [
+        f
+        for f in os.listdir(cur_directory)
+        if os.path.isfile(os.path.join(cur_directory, f))
+    ]
 
     for resource in resource_files:
         ls_executables.append(resource)
@@ -200,8 +195,8 @@ def regenerate_all_executables():
         if os.path.exists(output_file):
             os.remove(output_file)
 
-        with open(output_file, 'wb') as fs_stream:
-            with open(resource, 'rb') as st_resource:
+        with open(output_file, "wb") as fs_stream:
+            with open(resource, "rb") as st_resource:
                 while True:
                     buffer = st_resource.read(EXECUTABLE_BLOCK_SIZE)
                     if not buffer:
@@ -216,7 +211,7 @@ def generate_fv_main_file(lsFFsFiles):
         os.remove(FV_MAIN_INF_NAME)
 
     try:
-        with open(FV_MAIN_INF_NAME, 'w') as sw:
+        with open(FV_MAIN_INF_NAME, "w") as sw:
             sw.write("[options]\n")
             sw.write("EFI_BLOCK_SIZE  = 0x40\n")
             sw.write("EFI_NUM_BLOCKS   =  0x0\n")
@@ -256,13 +251,14 @@ def generate_fv(s_output_file_name, ls_ffs, s_gen_fv, tools_dir=None):
     if platform.system() == "Linux":
         if tools_dir is None:
             tools_dir = os.path.dirname(os.path.realpath(__file__))
-        sFVCommand = f"{tools_dir}/GenFv -o {s_output_file_name} -i {FV_MAIN_INF_NAME} -v"
+        sFVCommand = (
+            f"{tools_dir}/GenFv -o {s_output_file_name} -i {FV_MAIN_INF_NAME} -v"
+        )
         execute_command_linux(sFVCommand)
 
     if platform.system() == "Windows":
         sFVCommand = f"{s_gen_fv} -o {s_output_file_name} -i {FV_MAIN_INF_NAME} -v"
         execute_command(sFVCommand)
-
 
     if not os.path.exists(s_output_file_name):
         bReturn = False
@@ -290,9 +286,9 @@ def validate_sys_fw_ver_binary_file(fw_ver_binary_data):
             print("Expected REVISION value found")
 
         # Validating the signature of binary file
-        bytes_signature = struct.pack('<Q', fw_ver_binary_data.Signature)
+        bytes_signature = struct.pack("<Q", fw_ver_binary_data.Signature)
 
-        if SYS_FW_VERSION_DATA_SIGNATURE != bytes_signature.decode('ascii'):
+        if SYS_FW_VERSION_DATA_SIGNATURE != bytes_signature.decode("ascii"):
             print("Unexpected SIGNATURE value found")
             b_return = False
         elif print_logs >= 1:
@@ -302,7 +298,9 @@ def validate_sys_fw_ver_binary_file(fw_ver_binary_data):
         temp_version_data_crc32 = fw_ver_binary_data.VersionDataCrc32
         fw_ver_binary_data.VersionDataCrc32 = 0
 
-        if temp_version_data_crc32 != CalcCRC32_i(fw_ver_binary_data.to_bytes(), fw_ver_binary_data.VersionDataSize):
+        if temp_version_data_crc32 != CalcCRC32_i(
+            fw_ver_binary_data.to_bytes(), fw_ver_binary_data.VersionDataSize
+        ):
             print("Unexpected VersionDataSize value found")
             b_return = False
         elif print_logs >= 1:
@@ -322,19 +320,37 @@ def calc_crc32(data, size):
 
 def get_versions_from_sys_fw_ver_binary_file(s_fw_ver_binary_file, fw_ver_binary_data):
     try:
-        with open(s_fw_ver_binary_file, 'rb') as fs:
+        with open(s_fw_ver_binary_file, "rb") as fs:
             file_content = fs.read()
         fw_ver_binary_data = QSYS_FW_VERSION_DATA()
         fw_ver_binary_data = QSYS_FW_VERSION_DATA.from_bytes(file_content)
 
         if print_logs >= 2:
             print()
-            print("get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.Signature: ", fw_ver_binary_data.Signature)
-            print("get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.Revision", fw_ver_binary_data.Revision)
-            print("get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.VersionDataSize", fw_ver_binary_data.VersionDataSize)
-            print("get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.VersionDataCrc32", fw_ver_binary_data.VersionDataCrc32)
-            print("get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.FwVersion", fw_ver_binary_data.FwVersion)
-            print("get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.LowestSupportedFwVersion", fw_ver_binary_data.LowestSupportedFwVersion)
+            print(
+                "get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.Signature: ",
+                fw_ver_binary_data.Signature,
+            )
+            print(
+                "get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.Revision",
+                fw_ver_binary_data.Revision,
+            )
+            print(
+                "get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.VersionDataSize",
+                fw_ver_binary_data.VersionDataSize,
+            )
+            print(
+                "get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.VersionDataCrc32",
+                fw_ver_binary_data.VersionDataCrc32,
+            )
+            print(
+                "get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.FwVersion",
+                fw_ver_binary_data.FwVersion,
+            )
+            print(
+                "get_versions_from_sys_fw_ver_binary_file :: fw_ver_binary_data.LowestSupportedFwVersion",
+                fw_ver_binary_data.LowestSupportedFwVersion,
+            )
             print()
         return fw_ver_binary_data
 
@@ -345,23 +361,35 @@ def get_versions_from_sys_fw_ver_binary_file(s_fw_ver_binary_file, fw_ver_binary
 
 def guid_to_string(guid):
     fw_entry_UpdatePath_PartitionTypeGUID_uuid_bytes_obj = bytes(guid)
-    fw_entry_UpdatePath_PartitionTypeGUID__uuid_str = str(uuid.UUID(bytes=fw_entry_UpdatePath_PartitionTypeGUID_uuid_bytes_obj))
+    fw_entry_UpdatePath_PartitionTypeGUID__uuid_str = str(
+        uuid.UUID(bytes=fw_entry_UpdatePath_PartitionTypeGUID_uuid_bytes_obj)
+    )
     return fw_entry_UpdatePath_PartitionTypeGUID__uuid_str
 
 
 def c_sharp_guid_format(guid_array):
-    new_guid_array = (guid_array.bytes[3:4] + guid_array.bytes[2:3] + guid_array.bytes[1:2] + guid_array.bytes[0:1]
-                      + guid_array.bytes[5:6] + guid_array.bytes[4:5]
-                      + guid_array.bytes[7:8] + guid_array.bytes[6:7]
-                      + guid_array.bytes[8:]
-                    )
+    new_guid_array = (
+        guid_array.bytes[3:4]
+        + guid_array.bytes[2:3]
+        + guid_array.bytes[1:2]
+        + guid_array.bytes[0:1]
+        + guid_array.bytes[5:6]
+        + guid_array.bytes[4:5]
+        + guid_array.bytes[7:8]
+        + guid_array.bytes[6:7]
+        + guid_array.bytes[8:]
+    )
     return new_guid_array
 
 
-def generate_sys_fw_meta_data_file(fw_ver_binary_data, s_breaking_change_number, g_dynamic_var):
+def generate_sys_fw_meta_data_file(
+    fw_ver_binary_data, s_breaking_change_number, g_dynamic_var
+):
 
     if fw_ver_binary_data.FwVersion < fw_ver_binary_data.LowestSupportedFwVersion:
-        print("ERROR: Lowest Firmware version value is greater than or equal to current firmware version value.\n")
+        print(
+            "ERROR: Lowest Firmware version value is greater than or equal to current firmware version value.\n"
+        )
         return False
 
     # Check Metadata.dat file exists, if yes delete it.
@@ -386,39 +414,69 @@ def generate_sys_fw_meta_data_file(fw_ver_binary_data, s_breaking_change_number,
     else:
         # Use V3 Payload header format if MatchIdentifier not in XML.
         meta_data_header.Revision = SYS_FW_METADATA_HEADER_REVISION_V3
-        fw_entry_meta_data_size = ctypes.sizeof(FVC_h.QPAYLOAD_METADATA_FWENTRY) - ctypes.sizeof(ctypes.c_uint32) - ctypes.sizeof(ctypes.c_char * (2 * FVC_h.GlobalStaticVariable.MATCH_IDENTIFIER_NAME_MAX_SIZE))
+        fw_entry_meta_data_size = (
+            ctypes.sizeof(FVC_h.QPAYLOAD_METADATA_FWENTRY)
+            - ctypes.sizeof(ctypes.c_uint32)
+            - ctypes.sizeof(
+                ctypes.c_char
+                * (2 * FVC_h.GlobalStaticVariable.MATCH_IDENTIFIER_NAME_MAX_SIZE)
+            )
+        )
 
     meta_data_header_temp = FVC_h.QPAYLOAD_METADATA_HEADER()
-    meta_data_header.Size = len(meta_data_header_temp.to_bytes()) - (4 * struct.calcsize('<I'))
+    meta_data_header.Size = len(meta_data_header_temp.to_bytes()) - (
+        4 * struct.calcsize("<I")
+    )
     meta_data_header.FirmwareVersion = fw_ver_binary_data.FwVersion
-    meta_data_header.LowestSupportedVersion = fw_ver_binary_data.LowestSupportedFwVersion
+    meta_data_header.LowestSupportedVersion = (
+        fw_ver_binary_data.LowestSupportedFwVersion
+    )
     meta_data_header.BreakingChangeNumber = int(s_breaking_change_number)
     meta_data_header.Reserved1 = 0x0
     meta_data_header.Reserved2 = 0x0
     meta_data_header.EntryCount = len(g_dynamic_var.QpayloadFwEntryList)
 
-    with open(SYS_FW_METADATA_FILE, 'wb') as fs:
-        header_bytes = ctypes.string_at(ctypes.byref(meta_data_header), ctypes.sizeof(meta_data_header))
+    with open(SYS_FW_METADATA_FILE, "wb") as fs:
+        header_bytes = ctypes.string_at(
+            ctypes.byref(meta_data_header), ctypes.sizeof(meta_data_header)
+        )
         fs.write(header_bytes)
 
         # Write metaData fw entries to metadata.dat
         for fw_entry in g_dynamic_var.QpayloadFwEntryList:
-
-            new_uuid_obj = c_sharp_guid_format(uuid.UUID(bytes=bytes(fw_entry.FileGuid)))
+            new_uuid_obj = c_sharp_guid_format(
+                uuid.UUID(bytes=bytes(fw_entry.FileGuid))
+            )
             fw_entry.FileGuid = (ctypes.c_byte * 16)(*new_uuid_obj)
 
-            UpdatePath_PartitionName_string = ''.join(chr(b) for b in fw_entry.UpdatePath.PartitionName)
-            UpdatePath_PartitionName_string = UpdatePath_PartitionName_string.replace("\0", "")
-            fw_entry.UpdatePath.PartitionName[:len(UpdatePath_PartitionName_string.encode('utf-16-le'))] = UpdatePath_PartitionName_string.encode('utf-16-le')
+            UpdatePath_PartitionName_string = "".join(
+                chr(b) for b in fw_entry.UpdatePath.PartitionName
+            )
+            UpdatePath_PartitionName_string = UpdatePath_PartitionName_string.replace(
+                "\0", ""
+            )
+            fw_entry.UpdatePath.PartitionName[
+                : len(UpdatePath_PartitionName_string.encode("utf-16-le"))
+            ] = UpdatePath_PartitionName_string.encode("utf-16-le")
 
-            new_uuid_obj = c_sharp_guid_format(uuid.UUID(bytes=bytes(fw_entry.UpdatePath.PartitionTypeGUID)))
+            new_uuid_obj = c_sharp_guid_format(
+                uuid.UUID(bytes=bytes(fw_entry.UpdatePath.PartitionTypeGUID))
+            )
             fw_entry.UpdatePath.PartitionTypeGUID = (ctypes.c_byte * 16)(*new_uuid_obj)
 
-            BackupPath_PartitionName_string = ''.join(chr(b) for b in fw_entry.BackupPath.PartitionName)
-            BackupPath_PartitionName_string = BackupPath_PartitionName_string.replace("\0", "")
-            fw_entry.BackupPath.PartitionName[:len(BackupPath_PartitionName_string.encode('utf-16-le'))] = BackupPath_PartitionName_string.encode('utf-16-le')
+            BackupPath_PartitionName_string = "".join(
+                chr(b) for b in fw_entry.BackupPath.PartitionName
+            )
+            BackupPath_PartitionName_string = BackupPath_PartitionName_string.replace(
+                "\0", ""
+            )
+            fw_entry.BackupPath.PartitionName[
+                : len(BackupPath_PartitionName_string.encode("utf-16-le"))
+            ] = BackupPath_PartitionName_string.encode("utf-16-le")
 
-            new_uuid_obj = c_sharp_guid_format(uuid.UUID(bytes=bytes(fw_entry.BackupPath.PartitionTypeGUID)))
+            new_uuid_obj = c_sharp_guid_format(
+                uuid.UUID(bytes=bytes(fw_entry.BackupPath.PartitionTypeGUID))
+            )
             fw_entry.BackupPath.PartitionTypeGUID = (ctypes.c_byte * 16)(*new_uuid_obj)
 
             bytes_data = fw_entry.to_bytes()
@@ -428,33 +486,36 @@ def generate_sys_fw_meta_data_file(fw_ver_binary_data, s_breaking_change_number,
 
 
 def process_sys_fw_ffs_creation(
-        s_xml_file_name,
-        s_fw_ver_binary_file,
-        s_gen_ffs,
-        s_breaking_change_number,
-        fw_ver_binary_data,
-        ls_ffs,
-        ls_paths,
-        g_dynamic_var,
-        tools_dir=None
-    ):
+    s_xml_file_name,
+    s_fw_ver_binary_file,
+    s_gen_ffs,
+    s_breaking_change_number,
+    fw_ver_binary_data,
+    ls_ffs,
+    ls_paths,
+    g_dynamic_var,
+    tools_dir=None,
+):
     try:
         #
         # Firmware version validation
         #
         if not os.path.exists(s_fw_ver_binary_file):
-            print("ERROR: Invalid SYSFW_VERSION.BIN file, please check the input file provided.\n")
+            print(
+                "ERROR: Invalid SYSFW_VERSION.BIN file, please check the input file provided.\n"
+            )
             return False
         elif print_logs >= 2:
             print("%s file found" % (s_fw_ver_binary_file))
 
-        fw_ver_binary_data = get_versions_from_sys_fw_ver_binary_file(s_fw_ver_binary_file, fw_ver_binary_data)
+        fw_ver_binary_data = get_versions_from_sys_fw_ver_binary_file(
+            s_fw_ver_binary_file, fw_ver_binary_data
+        )
         if not fw_ver_binary_data:
             print("ERROR: Error parsing SYSFW_VERSION.BIN file.")
             return False
         elif print_logs >= 2:
             print("%s parsed successfully" % (s_fw_ver_binary_file))
-
 
         if not validate_sys_fw_ver_binary_file(fw_ver_binary_data):
             print("ERROR: Wrong SYSFW_VERSION.BIN file is supplied")
@@ -465,7 +526,9 @@ def process_sys_fw_ffs_creation(
         #
         # Parse input XML
         #
-        if not xp.parse_input_xml(s_xml_file_name, s_breaking_change_number, g_dynamic_var):
+        if not xp.parse_input_xml(
+            s_xml_file_name, s_breaking_change_number, g_dynamic_var
+        ):
             print("ERROR: Error parsing XML file.")
             return False
         elif print_logs >= 2:
@@ -483,7 +546,9 @@ def process_sys_fw_ffs_creation(
         #
         # Create metadata
         #
-        if not generate_sys_fw_meta_data_file(fw_ver_binary_data, s_breaking_change_number, g_dynamic_var):
+        if not generate_sys_fw_meta_data_file(
+            fw_ver_binary_data, s_breaking_change_number, g_dynamic_var
+        ):
             print("ERROR: Failure creating metadata file. Aborting...\n")
             return False
         elif print_logs >= 2:
@@ -492,7 +557,9 @@ def process_sys_fw_ffs_creation(
         #
         # Generate FFS file of each input binary
         #
-        if not generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var, tools_dir):
+        if not generate_sys_fw_ffs_list(
+            ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var, tools_dir
+        ):
             print("ERROR: Error Generating FFS files.")
             return False
         elif print_logs >= 2:
@@ -504,26 +571,38 @@ def process_sys_fw_ffs_creation(
     return True
 
 
-def generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var, tools_dir=None):
+def generate_sys_fw_ffs_list(
+    ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var, tools_dir=None
+):
 
     try:
         for raw_fwentry in g_dynamic_var.XmlRawFwEntryList:
-
-            if raw_fwentry.Operation.lower() == g_dynamic_var.dOperationTypeByValue[FVC_h.FWENTRY_OPERATION_TYPE.IGNORE].lower():
+            if (
+                raw_fwentry.Operation.lower()
+                == g_dynamic_var.dOperationTypeByValue[
+                    FVC_h.FWENTRY_OPERATION_TYPE.IGNORE
+                ].lower()
+            ):
                 continue
 
-            s_file_name = raw_fwentry.InputBinary[:raw_fwentry.InputBinary.rfind(".")]
+            s_file_name = raw_fwentry.InputBinary[: raw_fwentry.InputBinary.rfind(".")]
             s_dir_path = get_dir_path(raw_fwentry, ls_paths)
 
             if s_dir_path is None:
-                print(f"ERROR: File {raw_fwentry.InputBinary} cannot be found in any of the search paths.\n")
+                print(
+                    f"ERROR: File {raw_fwentry.InputBinary} cannot be found in any of the search paths.\n"
+                )
                 return False
 
             #
             # Handle FFS file naming to avoid overwriting
             #
             if s_file_name + ".ffs" in ls_ffs:
-                temp_str = raw_fwentry.UpdatePath.PartitionName.lower().replace(s_file_name.lower(), "").strip('_')
+                temp_str = (
+                    raw_fwentry.UpdatePath.PartitionName.lower()
+                    .replace(s_file_name.lower(), "")
+                    .strip("_")
+                )
                 s_file_name = f"{s_file_name}_{temp_str}"
 
             print(f"INFO: Creating ffs file for {raw_fwentry.InputBinary}.")
@@ -535,7 +614,9 @@ def generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var, tools_d
                 if tools_dir is None:
                     tools_dir = os.path.dirname(os.path.realpath(__file__))
                 raw_fwentry_FileGuid_uuid_bytes_obj = bytes(raw_fwentry.FileGuid)
-                raw_fwentry_FileGuid_uuid_str = str(uuid.UUID(bytes=raw_fwentry_FileGuid_uuid_bytes_obj))
+                raw_fwentry_FileGuid_uuid_str = str(
+                    uuid.UUID(bytes=raw_fwentry_FileGuid_uuid_bytes_obj)
+                )
                 s_command = f"{tools_dir}/GenFfs -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {raw_fwentry_FileGuid_uuid_str} -s -v -i {os.path.join(s_dir_path, raw_fwentry.InputBinary)}"
                 execute_command_linux(s_command)
 
@@ -544,14 +625,16 @@ def generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var, tools_d
             #
             if platform.system() == "Windows":
                 raw_fwentry_FileGuid_uuid_bytes_obj = bytes(raw_fwentry.FileGuid)
-                raw_fwentry_FileGuid_uuid_str = str(uuid.UUID(bytes=raw_fwentry_FileGuid_uuid_bytes_obj))
+                raw_fwentry_FileGuid_uuid_str = str(
+                    uuid.UUID(bytes=raw_fwentry_FileGuid_uuid_bytes_obj)
+                )
                 s_command = f"{s_gen_ffs} -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {raw_fwentry_FileGuid_uuid_str} -s -v -i {os.path.join(s_dir_path, raw_fwentry.InputBinary)}"
                 execute_command(s_command)
 
             ls_ffs.append(s_file_name + ".ffs")
 
-        s_file_name = SYS_FW_METADATA_FILE[:SYS_FW_METADATA_FILE.rfind(".")]
-        s_guid = FVC_h.GlobalStaticVariable.FILE_GUID_METADATA_GUID.strip('{}')
+        s_file_name = SYS_FW_METADATA_FILE[: SYS_FW_METADATA_FILE.rfind(".")]
+        s_guid = FVC_h.GlobalStaticVariable.FILE_GUID_METADATA_GUID.strip("{}")
 
         print(f"INFO: Creating ffs file for {SYS_FW_METADATA_FILE}.")
         if platform.system() == "Linux":
@@ -582,8 +665,12 @@ def generate_sys_fw_ffs_list(ls_ffs, s_gen_ffs, ls_paths, g_dynamic_var, tools_d
 
 def print_help():
     print("<======== FvCreator.py Usage ======>\n")
-    print("[For System Firmware FV Creation]        FVCreator.py <output FV file> -FvType SYS_FW <input xml file with binary & guid combinations> <SysFwVersionBinaryFile> <Binary Search Path 1> <Binary Search Path 2> ...\n")
-    print("[For EC Device Firmware FV Creation]    FVCreator.py <output FV file> -FvType EC_FW <EC Firmware Binary path>")
+    print(
+        "[For System Firmware FV Creation]        FVCreator.py <output FV file> -FvType SYS_FW <input xml file with binary & guid combinations> <SysFwVersionBinaryFile> <Binary Search Path 1> <Binary Search Path 2> ...\n"
+    )
+    print(
+        "[For EC Device Firmware FV Creation]    FVCreator.py <output FV file> -FvType EC_FW <EC Firmware Binary path>"
+    )
     return
 
 
@@ -591,26 +678,23 @@ class Arguments:
     MINIMUM_ARGUMENT_COUNT = 4
     MAXIMUM_ARGUMENT_COUNT = 6
 
-
     def __init__(self):
         self.parameters = {}
-
 
     def ConstructConfData(self, args):
 
         self.parameters.clear()
-        splitter = re.compile(r'^-{1,2}|^/', re.IGNORECASE)
+        splitter = re.compile(r"^-{1,2}|^/", re.IGNORECASE)
         remover = re.compile(r"^['\"]?(.*?)['\"]?$", re.IGNORECASE)
         parameter = None
 
         for txt in args:
-
             parts = splitter.split(txt, maxsplit=2)
 
             if len(parts) == 1:
                 if parameter is not None:
                     if parameter not in self.parameters:
-                        parts[0] = remover.sub(r'\1', parts[0])
+                        parts[0] = remover.sub(r"\1", parts[0])
                         self.parameters[parameter] = parts[0]
                     parameter = None
 
@@ -623,7 +707,6 @@ class Arguments:
         if parameter is not None:
             if parameter not in self.parameters:
                 self.parameters[parameter] = "true"
-
 
     def __getitem__(self, Param):
         return self.parameters.get(Param)
@@ -645,13 +728,13 @@ def The_Main(args):
     # Extract --edk2-path if provided; derive tools_dir from it
     args = list(args)
     for i, arg in enumerate(args):
-        if arg in ('--edk2-path', '-edk2path') and i + 1 < len(args):
+        if arg in ("--edk2-path", "-edk2path") and i + 1 < len(args):
             edk2_path = args[i + 1]
             if platform.system() == "Linux":
-                tools_dir = os.path.join(edk2_path, 'BaseTools', 'Source', 'C', 'bin')
+                tools_dir = os.path.join(edk2_path, "BaseTools", "Source", "C", "bin")
             elif platform.system() == "Windows":
                 tools_dir = edk2_path
-            del args[i:i + 2]
+            del args[i : i + 2]
             break
 
     # fv_type = FV_TYPE.UNKNOWN
@@ -664,7 +747,10 @@ def The_Main(args):
 
     if args[1].lower() == "-FvType".lower():
         if args[2].lower() != "SYS_FW".lower() and args[2].lower() != "EC_FW".lower():
-            print("Invalid FvType detected, expecting 'SYS_FW' or 'EC_FW' got %s" % (args[2]))
+            print(
+                "Invalid FvType detected, expecting 'SYS_FW' or 'EC_FW' got %s"
+                % (args[2])
+            )
         else:
             fv_type = args[2].lower()
     else:
@@ -678,15 +764,17 @@ def The_Main(args):
         for i in range(5, len(args)):
             ls_paths.append(args[i])
 
-        r = process_sys_fw_ffs_creation(s_xml_file_name=s_xml_file_name,
-                                        s_fw_ver_binary_file=s_fw_ver_binary_file,
-                                        s_gen_ffs=s_gen_ffs,
-                                        s_breaking_change_number=s_breaking_change_number,
-                                        fw_ver_binary_data=fw_ver_binary_data,
-                                        ls_ffs=ls_ffs,
-                                        ls_paths=ls_paths,
-                                        g_dynamic_var=g_dynamic_var,
-                                        tools_dir=tools_dir)
+        r = process_sys_fw_ffs_creation(
+            s_xml_file_name=s_xml_file_name,
+            s_fw_ver_binary_file=s_fw_ver_binary_file,
+            s_gen_ffs=s_gen_ffs,
+            s_breaking_change_number=s_breaking_change_number,
+            fw_ver_binary_data=fw_ver_binary_data,
+            ls_ffs=ls_ffs,
+            ls_paths=ls_paths,
+            g_dynamic_var=g_dynamic_var,
+            tools_dir=tools_dir,
+        )
         if not r:
             print("process_sys_fw_ffs_creation failed")
 

--- a/uefi_capsule_generation/FVCreation.py
+++ b/uefi_capsule_generation/FVCreation.py
@@ -718,8 +718,6 @@ def The_Main(args):
     ls_paths = []
     g_dynamic_var = FVC_h.GlobalDynamicVariable()
     fw_ver_binary_data = FVC_h.QSYS_FW_VERSION_DATA()
-    fw_version = 0
-    lowest_supported_fw_version = 0
     s_gen_ffs = "GenFfs.exe"
     s_gen_fv = "GenFv.exe"
     tools_dir = None

--- a/uefi_capsule_generation/FVCreation_header.py
+++ b/uefi_capsule_generation/FVCreation_header.py
@@ -4,11 +4,9 @@
 # --------------------------------------------------------------------
 
 
-from enum import Enum, IntEnum
-import struct
+from enum import IntEnum
 import uuid
 from collections import deque
-import traceback
 import ctypes
 
 

--- a/uefi_capsule_generation/FVCreation_header.py
+++ b/uefi_capsule_generation/FVCreation_header.py
@@ -397,7 +397,7 @@ class GlobalDynamicVariable:
         FWENTRY_BACKUP_TYPE.FAT_FILE: "BACKUP_FAT_FILE",
     }
 
-    XmlRawFwEntryList = deque()
-    QpayloadFwEntryList = deque()
+    XmlRawFwEntryList: deque = deque()
+    QpayloadFwEntryList: deque = deque()
     DeviceFlashType = None
     isMatchIdentifierInXML = False

--- a/uefi_capsule_generation/FVCreation_header.py
+++ b/uefi_capsule_generation/FVCreation_header.py
@@ -4,10 +4,10 @@
 # --------------------------------------------------------------------
 
 
-from enum import IntEnum
+import ctypes
 import uuid
 from collections import deque
-import ctypes
+from enum import IntEnum
 
 
 class FWENTRY_OPERATION_TYPE(IntEnum):

--- a/uefi_capsule_generation/FVCreation_header.py
+++ b/uefi_capsule_generation/FVCreation_header.py
@@ -1,4 +1,3 @@
-
 # --------------------------------------------------------------------
 # Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -11,6 +10,7 @@ import uuid
 from collections import deque
 import traceback
 import ctypes
+
 
 class FWENTRY_OPERATION_TYPE(IntEnum):
     IGNORE = 0x00000000
@@ -122,36 +122,50 @@ class GlobalStaticVariable:
 
 
 class FWENTRY_DEVICE_PATH(ctypes.Structure):
-
     _pack_ = 1
     _fields_ = [
         ("DiskType", ctypes.c_uint32),
-        ("PartitionName", ctypes.c_byte * (2 * GlobalStaticVariable.PARTITION_NAME_MAX_SIZE)),
+        (
+            "PartitionName",
+            ctypes.c_byte * (2 * GlobalStaticVariable.PARTITION_NAME_MAX_SIZE),
+        ),
         ("PartitionTypeGUID", ctypes.c_byte * 16),
-        ("FileName", ctypes.c_byte * (2 * GlobalStaticVariable.FILE_NAME_MAX_SIZE))
+        ("FileName", ctypes.c_byte * (2 * GlobalStaticVariable.FILE_NAME_MAX_SIZE)),
     ]
 
     def __init__(self, pType=0):
         self.DiskType = pType
-        self.PartitionName = (ctypes.c_byte * (2 * GlobalStaticVariable.PARTITION_NAME_MAX_SIZE))()
-        self.PartitionTypeGUID = (ctypes.c_byte * 16).from_buffer_copy(uuid.UUID(int=0).bytes)
-        self.FileName = (ctypes.c_byte * (2 * GlobalStaticVariable.FILE_NAME_MAX_SIZE))()
+        self.PartitionName = (
+            ctypes.c_byte * (2 * GlobalStaticVariable.PARTITION_NAME_MAX_SIZE)
+        )()
+        self.PartitionTypeGUID = (ctypes.c_byte * 16).from_buffer_copy(
+            uuid.UUID(int=0).bytes
+        )
+        self.FileName = (
+            ctypes.c_byte * (2 * GlobalStaticVariable.FILE_NAME_MAX_SIZE)
+        )()
 
     def copy_from(self, devPath):
         self.DiskType = devPath.DiskType
-        ctypes.memmove(self.PartitionName, devPath.PartitionName, ctypes.sizeof(self.PartitionName))
-        self.PartitionTypeGUID = (ctypes.c_byte * 16).from_buffer_copy(devPath.PartitionTypeGUID)
+        ctypes.memmove(
+            self.PartitionName, devPath.PartitionName, ctypes.sizeof(self.PartitionName)
+        )
+        self.PartitionTypeGUID = (ctypes.c_byte * 16).from_buffer_copy(
+            devPath.PartitionTypeGUID
+        )
         ctypes.memmove(self.FileName, devPath.FileName, ctypes.sizeof(self.FileName))
 
     def equals(self, devPath):
-        base_partition_name = ''.join(self.PartitionName)
-        base_file_name = ''.join(self.FileName)
-        target_partition_name = ''.join(devPath.PartitionName)
-        target_file_name = ''.join(devPath.FileName)
-        return (self.DiskType == devPath.DiskType and
-                base_partition_name == target_partition_name and
-                self.PartitionTypeGUID[:] == devPath.PartitionTypeGUID[:] and
-                base_file_name == target_file_name)
+        base_partition_name = "".join(self.PartitionName)
+        base_file_name = "".join(self.FileName)
+        target_partition_name = "".join(devPath.PartitionName)
+        target_file_name = "".join(devPath.FileName)
+        return (
+            self.DiskType == devPath.DiskType
+            and base_partition_name == target_partition_name
+            and self.PartitionTypeGUID[:] == devPath.PartitionTypeGUID[:]
+            and base_file_name == target_file_name
+        )
 
     def to_bytes(self):
         return bytes(self)
@@ -162,12 +176,11 @@ class XML_RAW_FWENTRY_DEVICE_PATH(ctypes.Structure):
         ("DiskType", ctypes.c_wchar_p),
         ("PartitionName", ctypes.c_wchar_p),
         ("PartitionTypeGUID", ctypes.c_wchar_p),
-        ("FileName", ctypes.c_wchar_p)
+        ("FileName", ctypes.c_wchar_p),
     ]
 
 
 class QPAYLOAD_METADATA_FWENTRY(ctypes.Structure):
-
     _pack_ = 1
     _fields_ = [
         ("FileGuid", ctypes.c_byte * 16),
@@ -177,7 +190,10 @@ class QPAYLOAD_METADATA_FWENTRY(ctypes.Structure):
         ("UpdatePath", FWENTRY_DEVICE_PATH),
         ("BackupPath", FWENTRY_DEVICE_PATH),
         ("Revision", ctypes.c_uint32),
-        ("MatchIdentifier", ctypes.c_char * (2 * GlobalStaticVariable.MATCH_IDENTIFIER_NAME_MAX_SIZE))
+        (
+            "MatchIdentifier",
+            ctypes.c_char * (2 * GlobalStaticVariable.MATCH_IDENTIFIER_NAME_MAX_SIZE),
+        ),
     ]
 
     def to_bytes(self):
@@ -194,7 +210,7 @@ class XML_RAW_FWENTRY(ctypes.Structure):
         ("BackupType", ctypes.c_wchar_p),
         ("UpdatePath", XML_RAW_FWENTRY_DEVICE_PATH),
         ("BackupPath", XML_RAW_FWENTRY_DEVICE_PATH),
-        ("MatchIdentifier", ctypes.c_wchar_p)
+        ("MatchIdentifier", ctypes.c_wchar_p),
     ]
 
 
@@ -209,7 +225,7 @@ class QPAYLOAD_METADATA_HEADER(ctypes.Structure):
         ("BreakingChangeNumber", ctypes.c_uint32),
         ("Reserved1", ctypes.c_uint32),
         ("Reserved2", ctypes.c_uint32),
-        ("EntryCount", ctypes.c_uint32)
+        ("EntryCount", ctypes.c_uint32),
     ]
 
     def to_bytes(self):
@@ -223,7 +239,7 @@ class QSYS_FW_VERSION_DATA(ctypes.Structure):
         ("VersionDataSize", ctypes.c_uint32),
         ("VersionDataCrc32", ctypes.c_uint32),
         ("FwVersion", ctypes.c_uint32),
-        ("LowestSupportedFwVersion", ctypes.c_uint32)
+        ("LowestSupportedFwVersion", ctypes.c_uint32),
     ]
 
     def to_bytes(self):
@@ -248,12 +264,12 @@ class GlobalDynamicVariable:
         "\\ACPI\\FACP.ACP": GlobalStaticVariable.FILE_GUID_FACP_ACPI,
         "\\ACPI\\FACS.ACP": GlobalStaticVariable.FILE_GUID_FACS_ACPI,
         "\\ACPI\\FPDT.ACP": GlobalStaticVariable.FILE_GUID_FPDT_ACPI,
-        "\\ACPI\\MADT.ACP": GlobalStaticVariable.FILE_GUID_MADT_ACPI
+        "\\ACPI\\MADT.ACP": GlobalStaticVariable.FILE_GUID_MADT_ACPI,
     }
 
     dFileGuidByDestDppItemFile = {
         "OPM_PUB.PROVISION": GlobalStaticVariable.FILE_GUID_OPM_PUB_PROVISION,
-        "OPM_PRIV.PROVISION": GlobalStaticVariable.FILE_GUID_OPM_PRIV_PROVISION
+        "OPM_PRIV.PROVISION": GlobalStaticVariable.FILE_GUID_OPM_PRIV_PROVISION,
     }
 
     dDiskTypeByString = {
@@ -274,7 +290,7 @@ class GlobalDynamicVariable:
         "UFS_LUN6": FWENTRY_DISK_TYPE.LUN6,
         "UFS_LUN7": FWENTRY_DISK_TYPE.LUN7,
         "SPINOR": FWENTRY_DISK_TYPE.SPINOR,
-        "NVME": FWENTRY_DISK_TYPE.NVME
+        "NVME": FWENTRY_DISK_TYPE.NVME,
     }
 
     dDiskTypeByValue = {
@@ -295,21 +311,21 @@ class GlobalDynamicVariable:
         FWENTRY_DISK_TYPE.LUN6: "UFS_LUN6",
         FWENTRY_DISK_TYPE.LUN7: "UFS_LUN7",
         FWENTRY_DISK_TYPE.SPINOR: "SPINOR",
-        FWENTRY_DISK_TYPE.NVME: "NVME"
+        FWENTRY_DISK_TYPE.NVME: "NVME",
     }
 
     dFlashTypeByString = {
         "EMMC": FlashType.EMMC,
         "UFS": FlashType.UFS,
         "NORNVME": FlashType.NORNVME,
-        "NORUFS": FlashType.NORUFS
+        "NORUFS": FlashType.NORUFS,
     }
 
     dFlashTypeByValue = {
         FlashType.EMMC: "EMMC",
         FlashType.UFS: "UFS",
         FlashType.NORNVME: "NORNVME",
-        FlashType.NORUFS: "NORUFS"
+        FlashType.NORUFS: "NORUFS",
     }
 
     dFlashTypeByDiskType = {
@@ -330,29 +346,29 @@ class GlobalDynamicVariable:
         FWENTRY_DISK_TYPE.LUN6: [FlashType.UFS],
         FWENTRY_DISK_TYPE.LUN7: [FlashType.UFS],
         FWENTRY_DISK_TYPE.SPINOR: [FlashType.NORNVME, FlashType.NORUFS],
-        FWENTRY_DISK_TYPE.NVME: [FlashType.NORNVME]
+        FWENTRY_DISK_TYPE.NVME: [FlashType.NORNVME],
     }
 
     dOperationTypeByString = {
         "IGNORE": FWENTRY_OPERATION_TYPE.IGNORE,
-        "UPDATE": FWENTRY_OPERATION_TYPE.UPDATE
+        "UPDATE": FWENTRY_OPERATION_TYPE.UPDATE,
     }
 
     dOperationTypeByValue = {
         FWENTRY_OPERATION_TYPE.IGNORE: "IGNORE",
-        FWENTRY_OPERATION_TYPE.UPDATE: "UPDATE"
+        FWENTRY_OPERATION_TYPE.UPDATE: "UPDATE",
     }
 
     dOperationPathTypeByString = {
         "SOURCE": FWENTRY_OPERATION_PATH_TYPE.SOURCE,
         "DEST": FWENTRY_OPERATION_PATH_TYPE.DEST,
-        "BACKUP": FWENTRY_OPERATION_PATH_TYPE.BACKUP
+        "BACKUP": FWENTRY_OPERATION_PATH_TYPE.BACKUP,
     }
 
     dOperationPathTypeByValue = {
         FWENTRY_OPERATION_PATH_TYPE.SOURCE: "SOURCE",
         FWENTRY_OPERATION_PATH_TYPE.DEST: "DEST",
-        FWENTRY_OPERATION_PATH_TYPE.BACKUP: "BACKUP"
+        FWENTRY_OPERATION_PATH_TYPE.BACKUP: "BACKUP",
     }
 
     dUpdateTypeByString = {
@@ -361,7 +377,7 @@ class GlobalDynamicVariable:
         "UPDATE_DPP_QCOM": FWENTRY_UPDATE_TYPE.DPP_QCOM,
         "UPDATE_DPP_OEM": FWENTRY_UPDATE_TYPE.DPP_OEM,
         "UPDATE_OPM_PRIV_KEY": FWENTRY_UPDATE_TYPE.OPM_PRIV_KEY,
-        "UPDATE_FWCLASS_GUID": FWENTRY_UPDATE_TYPE.FWCLASS_GUID
+        "UPDATE_FWCLASS_GUID": FWENTRY_UPDATE_TYPE.FWCLASS_GUID,
     }
 
     dUpdateTypeByValue = {
@@ -370,17 +386,17 @@ class GlobalDynamicVariable:
         FWENTRY_UPDATE_TYPE.DPP_QCOM: "UPDATE_DPP_QCOM",
         FWENTRY_UPDATE_TYPE.DPP_OEM: "UPDATE_DPP_OEM",
         FWENTRY_UPDATE_TYPE.OPM_PRIV_KEY: "UPDATE_OPM_PRIV_KEY",
-        FWENTRY_UPDATE_TYPE.FWCLASS_GUID: "UPDATE_FWCLASS_GUID"
+        FWENTRY_UPDATE_TYPE.FWCLASS_GUID: "UPDATE_FWCLASS_GUID",
     }
 
     dBackupTypeByString = {
         "BACKUP_PARTITION": FWENTRY_BACKUP_TYPE.PARTITION,
-        "BACKUP_FAT_FILE": FWENTRY_BACKUP_TYPE.FAT_FILE
+        "BACKUP_FAT_FILE": FWENTRY_BACKUP_TYPE.FAT_FILE,
     }
 
     dBackupTypeByValue = {
         FWENTRY_BACKUP_TYPE.PARTITION: "BACKUP_PARTITION",
-        FWENTRY_BACKUP_TYPE.FAT_FILE: "BACKUP_FAT_FILE"
+        FWENTRY_BACKUP_TYPE.FAT_FILE: "BACKUP_FAT_FILE",
     }
 
     XmlRawFwEntryList = deque()

--- a/uefi_capsule_generation/SYSFW_VERSION_program.py
+++ b/uefi_capsule_generation/SYSFW_VERSION_program.py
@@ -7,10 +7,6 @@
 import sys
 import os
 import re
-import shutil
-import struct
-import argparse
-from pathlib import Path
 
 import ctypes
 import traceback

--- a/uefi_capsule_generation/SYSFW_VERSION_program.py
+++ b/uefi_capsule_generation/SYSFW_VERSION_program.py
@@ -1,4 +1,3 @@
-
 # --------------------------------------------------------------------
 # Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -23,6 +22,7 @@ S_REVISION = "1.0"
 QSYS_FW_VERSION_DATA_VERSIONDATACRC32 = 0
 tempfile = ".\\python_version"
 
+
 class QSYS_FW_VERSION_DATA(ctypes.Structure):
     _pack_ = 1
     _fields_ = [
@@ -44,16 +44,31 @@ class QSYS_FW_VERSION_DATA(ctypes.Structure):
     def from_bytes(cls, byte_arr):
         try:
             version_data = cls()
-            ctypes.memmove(ctypes.addressof(version_data), byte_arr, ctypes.sizeof(version_data))
+            ctypes.memmove(
+                ctypes.addressof(version_data), byte_arr, ctypes.sizeof(version_data)
+            )
 
             if print_logs >= 3:
                 print("\n\n")
-                print("from_bytes :: in version_data.VersionDataCrc32:", version_data.VersionDataCrc32)
-                print("from_bytes :: in version_data.Signature:", version_data.Signature)
+                print(
+                    "from_bytes :: in version_data.VersionDataCrc32:",
+                    version_data.VersionDataCrc32,
+                )
+                print(
+                    "from_bytes :: in version_data.Signature:", version_data.Signature
+                )
                 print("from_bytes :: in version_data.Revision:", version_data.Revision)
-                print("from_bytes :: in version_data.FwVersion:", version_data.FwVersion)
-                print("from_bytes :: in version_data.LowestSupported:", version_data.LowestSupportedFwVersion)
-                print("from_bytes :: in version_data.VersionDataSize:", version_data.VersionDataSize)
+                print(
+                    "from_bytes :: in version_data.FwVersion:", version_data.FwVersion
+                )
+                print(
+                    "from_bytes :: in version_data.LowestSupported:",
+                    version_data.LowestSupportedFwVersion,
+                )
+                print(
+                    "from_bytes :: in version_data.VersionDataSize:",
+                    version_data.VersionDataSize,
+                )
 
             return version_data
 
@@ -66,17 +81,31 @@ class QSYS_FW_VERSION_DATA(ctypes.Structure):
         try:
             version_data = cls()
             new_data = {}
-            ctypes.memmove(ctypes.addressof(version_data), byte_arr, ctypes.sizeof(version_data))
+            ctypes.memmove(
+                ctypes.addressof(version_data), byte_arr, ctypes.sizeof(version_data)
+            )
 
             if print_logs >= 2:
                 print("\n\n")
-                print("get_values :: in version_data.VersionDataCrc32:", version_data.VersionDataCrc32)
-                print("get_values :: in version_data.Signature:", version_data.Signature)
+                print(
+                    "get_values :: in version_data.VersionDataCrc32:",
+                    version_data.VersionDataCrc32,
+                )
+                print(
+                    "get_values :: in version_data.Signature:", version_data.Signature
+                )
                 print("get_values :: in version_data.Revision:", version_data.Revision)
-                print("get_values :: in version_data.FwVersion:", version_data.FwVersion)
-                print("get_values :: in version_data.LowestSupported:", version_data.LowestSupportedFwVersion)
-                print("get_values :: in version_data.VersionDataSize:", version_data.VersionDataSize)
-
+                print(
+                    "get_values :: in version_data.FwVersion:", version_data.FwVersion
+                )
+                print(
+                    "get_values :: in version_data.LowestSupported:",
+                    version_data.LowestSupportedFwVersion,
+                )
+                print(
+                    "get_values :: in version_data.VersionDataSize:",
+                    version_data.VersionDataSize,
+                )
 
             s_revision = [None, None]
             s_revision[1] = str(version_data.Revision & 0x0000FFFF)
@@ -87,8 +116,8 @@ class QSYS_FW_VERSION_DATA(ctypes.Structure):
                 print("\n\n")
                 print("get_values :: new_data.Revision: ", new_data["Revision"])
 
-            signature_bytes = version_data.Signature.to_bytes(8, byteorder='little')
-            ascii_string = signature_bytes.decode('ascii')
+            signature_bytes = version_data.Signature.to_bytes(8, byteorder="little")
+            ascii_string = signature_bytes.decode("ascii")
 
             if print_logs >= 2:
                 print("\n\n")
@@ -110,34 +139,28 @@ class Arguments:
 
     def ConstructConfData(self, args):
         self.parameters.clear()
-        splitter = re.compile(r'^-{1,2}|^/', re.IGNORECASE)
+        splitter = re.compile(r"^-{1,2}|^/", re.IGNORECASE)
         remover = re.compile(r"^['\"]?(.*?)['\"]?$", re.IGNORECASE)
         parameter = None
 
         for txt in args:
-
             parts = splitter.split(txt, maxsplit=2)
             if len(parts) == 1:
-
                 if parameter is not None:
-
                     if parameter not in self.parameters:
-                        parts[0] = remover.sub(r'\1', parts[0])
+                        parts[0] = remover.sub(r"\1", parts[0])
                         self.parameters[parameter] = parts[0]
 
                     parameter = None
 
             elif len(parts) == 2:
-
                 if parameter is not None:
-
                     if parameter not in self.parameters:
                         self.parameters[parameter] = "true"
 
                 parameter = parts[1]
 
         if parameter is not None:
-
             if parameter not in self.parameters:
                 self.parameters[parameter] = "true"
 
@@ -155,7 +178,7 @@ def Reflect(data_b, l_i):
 
     for i in range(l_i):
         if (data_i & 0x1) != 0:
-            reff_i = reff_i | int(1 << (int(l_i-1) - i))
+            reff_i = reff_i | int(1 << (int(l_i - 1) - i))
 
         data_i = data_i >> 1
     return reff_i
@@ -164,18 +187,17 @@ def Reflect(data_b, l_i):
 def CalcCRC32(buffer_b, l_i):
     k_i = 8
     MSB_i = 0
-    gx_h = 0x04c11DB7
+    gx_h = 0x04C11DB7
     regs_h = 0xFFFFFFFF
     regsMask_h = 0xFFFFFFFF
     regsMSB_i = 0
 
     for i in range(l_i):
-
         DataByte_b = buffer_b[i]
         DataByte_b = bytes(Reflect(DataByte_b, 8))
 
         for j in range(k_i):
-            MSB = DataByte_b >> (k_i-1)
+            MSB = DataByte_b >> (k_i - 1)
             MSB = MSB & 1
             regsMSB_i = int(regs_h >> 31) & 1
             regs_h = regs_h << 1
@@ -192,7 +214,7 @@ def CalcCRC32(buffer_b, l_i):
 def CalcCRC32_i(buffer_b, l_i):
     k_i = 8
     MSB_i = 0
-    gx_h = 0x04c11DB7
+    gx_h = 0x04C11DB7
     regs_h = 0xFFFFFFFF
     regsMask_h = 0xFFFFFFFF
     regsMSB_i = 0
@@ -202,13 +224,12 @@ def CalcCRC32_i(buffer_b, l_i):
     regsMask_i = int(regsMask_h)
 
     for i in range(l_i):
-
         DataByte_b = buffer_b[i]
         DataByte_i = int(DataByte_b)
         DataByte_i = Reflect(DataByte_i, 8)
 
         for j in range(k_i):
-            MSB_i = DataByte_i >> (k_i-1)
+            MSB_i = DataByte_i >> (k_i - 1)
             MSB_i = MSB_i & 1
             regsMSB_i = int(regs_i >> 31) & 1
             regs_i = regs_i << 1
@@ -226,46 +247,53 @@ def generate_binary_file(args):
 
     FwVerBinaryData = QSYS_FW_VERSION_DATA()
     FwVerBinaryData.VersionDataCrc32 = QSYS_FW_VERSION_DATA_VERSIONDATACRC32
-    FwVerBinaryData.Signature = int.from_bytes(S_SIGNATURE.encode('ascii'), 'little')
-    sRevisionArr = S_REVISION.split('.')
+    FwVerBinaryData.Signature = int.from_bytes(S_SIGNATURE.encode("ascii"), "little")
+    sRevisionArr = S_REVISION.split(".")
     FwVerBinaryData.Revision = (int(sRevisionArr[0]) << 16) | int(sRevisionArr[1])
 
-    if args['FwVer']:
-        if not re.match(r'^\d+\.\d+\.\d+\.\d+$', args['FwVer']):
+    if args["FwVer"]:
+        if not re.match(r"^\d+\.\d+\.\d+\.\d+$", args["FwVer"]):
             print("ERROR: Value to the parameter -FwVer is not specified")
             return False
-        sFirmwareVersionArr = args['FwVer'].split('.')
-        FwVerBinaryData.FwVersion = ((int(sFirmwareVersionArr[2]) << 16) | int(sFirmwareVersionArr[3]))
+        sFirmwareVersionArr = args["FwVer"].split(".")
+        FwVerBinaryData.FwVersion = (int(sFirmwareVersionArr[2]) << 16) | int(
+            sFirmwareVersionArr[3]
+        )
     else:
         print("ERROR: Value to the parameter -FwVer is not specified")
         return False
 
-    if args['LFwVer']:
-        if not re.match(r'^\d+\.\d+\.\d+\.\d+$', args['LFwVer']):
+    if args["LFwVer"]:
+        if not re.match(r"^\d+\.\d+\.\d+\.\d+$", args["LFwVer"]):
             print("ERROR: Value to the parameter -FwVer is not specified")
             return False
-        sFirmwareLowVersionArr = args['LFwVer'].split('.')
-        FwVerBinaryData.LowestSupportedFwVersion = ((int(sFirmwareLowVersionArr[2]) << 16) | int(sFirmwareLowVersionArr[3]))
+        sFirmwareLowVersionArr = args["LFwVer"].split(".")
+        FwVerBinaryData.LowestSupportedFwVersion = (
+            int(sFirmwareLowVersionArr[2]) << 16
+        ) | int(sFirmwareLowVersionArr[3])
     else:
         print("ERROR: Value to the parameter -LFwVer is not specified")
         return False
 
-    if args['O']:
-        OutputBinary = args['O']
+    if args["O"]:
+        OutputBinary = args["O"]
         FileName = os.path.basename(OutputBinary)
     else:
         print("ERROR: Value to the parameter -o is not specified")
         return False
 
-
     if os.path.exists(OutputBinary):
         os.remove(OutputBinary)
 
     FwVerBinaryData.VersionDataSize = len(FwVerBinaryData.to_bytes())
-    FwVerBinaryData.VersionDataCrc32 = CalcCRC32_i(FwVerBinaryData.to_bytes(), FwVerBinaryData.VersionDataSize)
-    output_file_path = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), FileName)
+    FwVerBinaryData.VersionDataCrc32 = CalcCRC32_i(
+        FwVerBinaryData.to_bytes(), FwVerBinaryData.VersionDataSize
+    )
+    output_file_path = os.path.join(
+        os.path.dirname(os.path.abspath(sys.argv[0])), FileName
+    )
 
-    with open(output_file_path, 'wb') as fw_file:
+    with open(output_file_path, "wb") as fw_file:
         fw_file.write(FwVerBinaryData.to_bytes())
 
     return True
@@ -282,7 +310,7 @@ def get_fw_version_hex(args):
 
     FilePath = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), FileName)
 
-    with open(FilePath, mode='rb') as file:
+    with open(FilePath, mode="rb") as file:
         file_content = file.read()
 
     FwVerBinaryData = QSYS_FW_VERSION_DATA.from_bytes(file_content)
@@ -300,18 +328,17 @@ def get_ls_version_hex(args):
 
     FilePath = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), FileName)
 
-    with open(FilePath, mode='rb') as file:
+    with open(FilePath, mode="rb") as file:
         file_content = file.read()
 
     FwVerBinaryData = QSYS_FW_VERSION_DATA.from_bytes(file_content)
     print(hex(FwVerBinaryData.LowestSupportedFwVersion))
 
 
-
 def print_bin_contents(args):
 
-    if args['PrintAll']:
-        OutputBinary = args['PrintAll']
+    if args["PrintAll"]:
+        OutputBinary = args["PrintAll"]
         FileName = os.path.basename(OutputBinary)
     else:
         print("ERROR: Value to the parameter -PrintAll is not specified")
@@ -319,9 +346,8 @@ def print_bin_contents(args):
 
     FilePath = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), FileName)
 
-    with open(FilePath, mode='rb') as file:
+    with open(FilePath, mode="rb") as file:
         file_content = file.read()
-
 
     FwVerBinaryData = QSYS_FW_VERSION_DATA.from_bytes(file_content)
 
@@ -332,7 +358,10 @@ def print_bin_contents(args):
         print("\tFwVerBinaryData.Signature:", FwVerBinaryData.Signature)
         print("\tFwVerBinaryData.Revision:", FwVerBinaryData.Revision)
         print("\tFwVerBinaryData.FwVersion:", FwVerBinaryData.FwVersion)
-        print("\tFwVerBinaryData.LowestSupported:", FwVerBinaryData.LowestSupportedFwVersion)
+        print(
+            "\tFwVerBinaryData.LowestSupported:",
+            FwVerBinaryData.LowestSupportedFwVersion,
+        )
         print("\tFwVerBinaryData.VersionDataSize:", FwVerBinaryData.VersionDataSize)
         print("\n")
 
@@ -350,23 +379,28 @@ def ViewBinaryFile(ConfigurationHelper):
         return False
 
     if "View" in ConfigurationHelper:
-
         if print_logs >= 2:
-            print("ViewBinaryFile :: ConfigurationHelper['View']: ", ConfigurationHelper['View'])
+            print(
+                "ViewBinaryFile :: ConfigurationHelper['View']: ",
+                ConfigurationHelper["View"],
+            )
 
-        if ConfigurationHelper['O'] is not None:
-            InputBinPath = ConfigurationHelper['O']
+        if ConfigurationHelper["O"] is not None:
+            InputBinPath = ConfigurationHelper["O"]
 
         else:
-            print("ViewBinaryFile :: ERROR: Value to the parameter -View is not specified")
+            print(
+                "ViewBinaryFile :: ERROR: Value to the parameter -View is not specified"
+            )
             return False
 
-
     if not os.path.join(os.path.dirname(os.path.abspath(__file__)), InputBinPath):
-        print("ViewBinaryFile :: ERROR: Provided input file does not exist in given directory")
+        print(
+            "ViewBinaryFile :: ERROR: Provided input file does not exist in given directory"
+        )
         return False
 
-    with open(InputBinPath, mode='rb') as file:
+    with open(InputBinPath, mode="rb") as file:
         fs = file.read()
 
     FwVerBinaryData = QSYS_FW_VERSION_DATA.from_bytes(fs)
@@ -384,8 +418,9 @@ def ViewBinaryFile(ConfigurationHelper):
     s_lowest_version = [None, None]
     s_lowest_version[1] = str(FwVerBinaryData.LowestSupportedFwVersion & 0x0000FFFF)
     s_lowest_version[0] = str(FwVerBinaryData.LowestSupportedFwVersion >> 16)
-    FwVerBinaryData_LowestSupportedFwVersion = s_lowest_version[0] + "." + s_lowest_version[1]
-
+    FwVerBinaryData_LowestSupportedFwVersion = (
+        s_lowest_version[0] + "." + s_lowest_version[1]
+    )
 
     if print_logs >= 0:
         print("\n")
@@ -411,7 +446,10 @@ def The_Main(args):
 
     if print_logs >= 2:
         print("\n\n")
-        print("The_Main :: ConfigurationHelper.parameters: ", ConfigurationHelper.parameters)
+        print(
+            "The_Main :: ConfigurationHelper.parameters: ",
+            ConfigurationHelper.parameters,
+        )
 
     if "Gen" in ConfigurationHelper.parameters:
         generate_binary_file(ConfigurationHelper.parameters)

--- a/uefi_capsule_generation/SYSFW_VERSION_program.py
+++ b/uefi_capsule_generation/SYSFW_VERSION_program.py
@@ -4,11 +4,10 @@
 # --------------------------------------------------------------------
 
 
-import sys
+import ctypes
 import os
 import re
-
-import ctypes
+import sys
 import traceback
 
 print_logs = 1

--- a/uefi_capsule_generation/UpdateFvXml.py
+++ b/uefi_capsule_generation/UpdateFvXml.py
@@ -221,7 +221,7 @@ def main():
             safe_clone(repo_dir)
         target = get_target_name(args.T)
         if not target:
-            print(f"Provided target is Unknown !!! Please re-check")
+            print("Provided target is Unknown !!! Please re-check")
             sys.exit(1)
         partition_conf_path = os.path.join(
             repo_dir, "platforms", target, "ufs", "partitions.conf"

--- a/uefi_capsule_generation/UpdateFvXml.py
+++ b/uefi_capsule_generation/UpdateFvXml.py
@@ -21,10 +21,12 @@ SUPPORTED_PLATFORMS = {
     "QCS615": "qcs615-adp-air",
 }
 
+
 def get_target_name(soc_name):
     for platform, target in SUPPORTED_PLATFORMS.items():
         if soc_name == platform:
             return target
+
 
 def safe_clone(repo_dir):
     if not os.path.exists(repo_dir):
@@ -34,22 +36,25 @@ def safe_clone(repo_dir):
             print(f"Error cloning repo: {e}")
             sys.exit(1)
 
+
 def read_partitions_conf(partition_conf_path):
     try:
-        with open(partition_conf_path, 'r') as f:
+        with open(partition_conf_path, "r") as f:
             return f.readlines()
     except FileNotFoundError:
         print(f"Error: {partition_conf_path} not found.")
         sys.exit(1)
 
+
 def detect_storage_type_from_conf(lines):
     for line in lines:
-        if re.search(r'--type=ufs', line, re.IGNORECASE):
+        if re.search(r"--type=ufs", line, re.IGNORECASE):
             return "UFS"
-        elif re.search(r'--type=emmc', line, re.IGNORECASE):
+        elif re.search(r"--type=emmc", line, re.IGNORECASE):
             return "EMMC"
     print("Error: Could not detect StorageType from partitions.conf.")
     sys.exit(1)
+
 
 def parse_partition_info(args, lines, storage_type):
     partition_info = {}
@@ -91,12 +96,14 @@ def parse_partition_info(args, lines, storage_type):
         partition_info[name] = entry
     return partition_info
 
+
 def find_base_names(partition_info):
     base_names = set()
     for name in partition_info:
         if name.endswith("_a") and name[:-2] + "_b" in partition_info:
             base_names.add(name[:-2])
     return base_names
+
 
 def create_xml(args, base_names, partition_info):
     doc = minidom.Document()
@@ -125,7 +132,7 @@ def create_xml(args, base_names, partition_info):
             ("InputPath", "Images"),
             ("Operation", "IGNORE"),
             ("UpdateType", "UPDATE_PARTITION"),
-            ("BackupType", "BACKUP_PARTITION")
+            ("BackupType", "BACKUP_PARTITION"),
         ]:
             elem = doc.createElement(tag)
             elem.appendChild(doc.createTextNode(text))
@@ -135,7 +142,7 @@ def create_xml(args, base_names, partition_info):
         for tag, text in [
             ("DiskType", disk_type),
             ("PartitionName", f"{base}_a"),
-            ("PartitionTypeGUID", part_a["guid"])
+            ("PartitionTypeGUID", part_a["guid"]),
         ]:
             elem = doc.createElement(tag)
             elem.appendChild(doc.createTextNode(text))
@@ -146,7 +153,7 @@ def create_xml(args, base_names, partition_info):
         for tag, text in [
             ("DiskType", disk_type),
             ("PartitionName", f"{base}_b"),
-            ("PartitionTypeGUID", part_b["guid"])
+            ("PartitionTypeGUID", part_b["guid"]),
         ]:
             elem = doc.createElement(tag)
             elem.appendChild(doc.createTextNode(text))
@@ -156,31 +163,52 @@ def create_xml(args, base_names, partition_info):
         fvitems.appendChild(fw_entry)
     return doc
 
+
 def write_xml(doc, output_file="FvUpdate.xml"):
     with open(output_file, "wb") as f:
         xml_str = doc.toprettyxml(indent="  ", encoding="utf-8")
         f.write(xml_str)
 
+
 def main():
-    parser = argparse.ArgumentParser(description="Generate FvUpdate.xml from partitions.conf")
-    custom_usage = "UpdateFvXml.py [-h] (-T TARGET & -S {UFS,EMMC}) | [-F PARTITIONS_CONF]"
+    parser = argparse.ArgumentParser(
+        description="Generate FvUpdate.xml from partitions.conf"
+    )
+    custom_usage = (
+        "UpdateFvXml.py [-h] (-T TARGET & -S {UFS,EMMC}) | [-F PARTITIONS_CONF]"
+    )
     parser = argparse.ArgumentParser(usage=custom_usage)
-    parser.add_argument('-T', metavar='TARGET', help='Target argument')
-    parser.add_argument("-S", "--StorageType", choices=["UFS", "EMMC"], help="Specify storage type: UFS or EMMC")
-    parser.add_argument('-F', metavar='PARTITIONS_CONF', help='Partitions config argument')
-    parser.add_argument('--ptool-path', dest='ptool_path', default=None,
-                        help='Path to an existing qcom-ptool directory; '
-                             'when provided, the repository is not cloned')
+    parser.add_argument("-T", metavar="TARGET", help="Target argument")
+    parser.add_argument(
+        "-S",
+        "--StorageType",
+        choices=["UFS", "EMMC"],
+        help="Specify storage type: UFS or EMMC",
+    )
+    parser.add_argument(
+        "-F", metavar="PARTITIONS_CONF", help="Partitions config argument"
+    )
+    parser.add_argument(
+        "--ptool-path",
+        dest="ptool_path",
+        default=None,
+        help="Path to an existing qcom-ptool directory; "
+        "when provided, the repository is not cloned",
+    )
     args = parser.parse_args()
 
     repo_dir = args.ptool_path if args.ptool_path else DEFAULT_REPO_DIR
 
     if args.F:
         if args.StorageType:
-            print("Error: Do not provide -S/--StorageType when using -F/--partitions_conf. It will be auto-detected.")
+            print(
+                "Error: Do not provide -S/--StorageType when using -F/--partitions_conf. It will be auto-detected."
+            )
             sys.exit(1)
         if args.T:
-            print("Error: Do not provide -T/--StorageType when using -F/--partitions_conf.")
+            print(
+                "Error: Do not provide -T/--StorageType when using -F/--partitions_conf."
+            )
             sys.exit(1)
         partition_conf_path = args.F
         lines = read_partitions_conf(partition_conf_path)
@@ -195,7 +223,9 @@ def main():
         if not target:
             print(f"Provided target is Unknown !!! Please re-check")
             sys.exit(1)
-        partition_conf_path = os.path.join(repo_dir, "platforms", target, "ufs", "partitions.conf")
+        partition_conf_path = os.path.join(
+            repo_dir, "platforms", target, "ufs", "partitions.conf"
+        )
         lines = read_partitions_conf(partition_conf_path)
     else:
         print("Error: Invalid argument combination.")
@@ -205,10 +235,15 @@ def main():
     partition_info = parse_partition_info(args, lines, args.StorageType)
     base_names = find_base_names(partition_info)
     if not base_names:
-        print("Warning: No partition pairs (_a/_b) found. FvUpdate.xml will not contain FwEntry blocks.")
+        print(
+            "Warning: No partition pairs (_a/_b) found. FvUpdate.xml will not contain FwEntry blocks."
+        )
     doc = create_xml(args, base_names, partition_info)
     write_xml(doc)
-    print(f"FvUpdate.xml has been created successfully with StorageType={args.StorageType}.")
+    print(
+        f"FvUpdate.xml has been created successfully with StorageType={args.StorageType}."
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/uefi_capsule_generation/UpdateFvXml.py
+++ b/uefi_capsule_generation/UpdateFvXml.py
@@ -3,12 +3,12 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 # --------------------------------------------------------------------
 
+import argparse
 import os
 import re
-import argparse
 import subprocess
-from xml.dom import minidom
 import sys
+from xml.dom import minidom
 
 REPO_URL = "https://github.com/qualcomm-linux/qcom-ptool.git"
 REPO_DIR = "qcom-ptool"

--- a/uefi_capsule_generation/UpdateJsonParameters.py
+++ b/uefi_capsule_generation/UpdateJsonParameters.py
@@ -20,16 +20,56 @@ import traceback
 
 
 def ParseArguments():
-    parser = argparse.ArgumentParser(description='Process input arguments.')
-    parser.add_argument('-j', '--json_file', type=str, dest='JsonFile', help='Path to input JSON file')
-    parser.add_argument('-f', '--fw_type', type=str, dest='FwType', help='Firmware Type [SYS_FW/EC_FW]')
-    parser.add_argument('-b', '--bin_file', type=str, dest='BinFile', help='Path to System Firmware Version Binary / Embedded Controller Firmware Binary File')
-    parser.add_argument('-t', '--tool_path', type=str, dest='SigningToolPath', help='Path to OpenSSL signing tool')
-    parser.add_argument('-p', '--private_cert', type=str, dest='OpenSslSignerPrivateCertFile', help='OpenSSL signer private certificate filename')
-    parser.add_argument('-x', '--public_cert', type=str, dest='OpenSslTrustedPublicCertFile', help='OpenSSL other public certificate filename.')
-    parser.add_argument('-oc', '--other_cert', type=str, dest='OpenSslOtherPublicCertFile', help='OpenSSL trusted public certificate filename.')
-    parser.add_argument('-pf', '--payload_file', type=str, dest='Payload', help='Path to the payload file')
-    parser.add_argument('-g', '--guid', type=str, dest='Guid', help='System FMP GUID')
+    parser = argparse.ArgumentParser(description="Process input arguments.")
+    parser.add_argument(
+        "-j", "--json_file", type=str, dest="JsonFile", help="Path to input JSON file"
+    )
+    parser.add_argument(
+        "-f", "--fw_type", type=str, dest="FwType", help="Firmware Type [SYS_FW/EC_FW]"
+    )
+    parser.add_argument(
+        "-b",
+        "--bin_file",
+        type=str,
+        dest="BinFile",
+        help="Path to System Firmware Version Binary / Embedded Controller Firmware Binary File",
+    )
+    parser.add_argument(
+        "-t",
+        "--tool_path",
+        type=str,
+        dest="SigningToolPath",
+        help="Path to OpenSSL signing tool",
+    )
+    parser.add_argument(
+        "-p",
+        "--private_cert",
+        type=str,
+        dest="OpenSslSignerPrivateCertFile",
+        help="OpenSSL signer private certificate filename",
+    )
+    parser.add_argument(
+        "-x",
+        "--public_cert",
+        type=str,
+        dest="OpenSslTrustedPublicCertFile",
+        help="OpenSSL other public certificate filename.",
+    )
+    parser.add_argument(
+        "-oc",
+        "--other_cert",
+        type=str,
+        dest="OpenSslOtherPublicCertFile",
+        help="OpenSSL trusted public certificate filename.",
+    )
+    parser.add_argument(
+        "-pf",
+        "--payload_file",
+        type=str,
+        dest="Payload",
+        help="Path to the payload file",
+    )
+    parser.add_argument("-g", "--guid", type=str, dest="Guid", help="System FMP GUID")
     args = parser.parse_args()
 
     return args
@@ -52,31 +92,38 @@ def create_config():
     Payloads_entry_dict["OpenSslTrustedPublicCertFile"] = ""
     Payloads_entry_dict["SigningToolPath"] = ""
 
-    config_json_data['Payloads'] = [Payloads_entry_dict]
+    config_json_data["Payloads"] = [Payloads_entry_dict]
 
-    with open('config.json', 'w') as json_file:
+    with open("config.json", "w") as json_file:
         json.dump(config_json_data, json_file, indent=4)
+
 
 def ExtractEcFwVersions(StringData, SubString):
     try:
         if not StringData:
-            print('Empty string data!!')
+            print("Empty string data!!")
             sys.exit(1)
 
         if not SubString:
-            print('Empty sub string data!!')
+            print("Empty sub string data!!")
             sys.exit(1)
 
         offset = StringData.find(SubString)
         index = offset + len(SubString)
-        FwVerMain = ((ord(StringData[index+0]) - ord('0') ) * 10 + (ord(StringData[index+1]) - ord('0')))
-        FwVerSub  = ((ord(StringData[index+3]) - ord('0') ) * 10 + (ord(StringData[index+4]) - ord('0')))
-        FwVerTest = ((ord(StringData[index+6]) - ord('0') ) * 10 + (ord(StringData[index+7]) - ord('0')))
+        FwVerMain = (ord(StringData[index + 0]) - ord("0")) * 10 + (
+            ord(StringData[index + 1]) - ord("0")
+        )
+        FwVerSub = (ord(StringData[index + 3]) - ord("0")) * 10 + (
+            ord(StringData[index + 4]) - ord("0")
+        )
+        FwVerTest = (ord(StringData[index + 6]) - ord("0")) * 10 + (
+            ord(StringData[index + 7]) - ord("0")
+        )
         version = (FwVerSub << 16) | FwVerTest
-        return ('0x{:08x}'.format(version))
+        return "0x{:08x}".format(version)
 
     except Exception as e:
-        print('Error occurred while extracting EC version: {0}.'.format(e))
+        print("Error occurred while extracting EC version: {0}.".format(e))
         sys.exit(1)
 
 
@@ -85,22 +132,30 @@ def GetEcFirmwareInfo(args):
     try:
         # Check if EcBinFilePath path is valid
         if not os.path.exists(EcBinFilePath):
-            print('Invalid EC firmware version file: {0}'.format(EcBinFilePath))
+            print("Invalid EC firmware version file: {0}".format(EcBinFilePath))
             sys.exit(1)
 
         with open(EcBinFilePath, "rb") as file:
             BinaryData = file.read()
-            StringData = BinaryData.decode('ISO-8859-1')
-            args.FwVersion = ExtractEcFwVersions(StringData, 'EC VER:') # Retrieve EC Firmware Version
-            args.LowestSupportedVersion = ExtractEcFwVersions(StringData, 'LsFv:') # Retrieve Lowest Supported EC Firmware Version
-            print('EC Firmware Version is {0}, lowest supported version: {1}'.format(args.FwVersion, args.LowestSupportedVersion))
+            StringData = BinaryData.decode("ISO-8859-1")
+            args.FwVersion = ExtractEcFwVersions(
+                StringData, "EC VER:"
+            )  # Retrieve EC Firmware Version
+            args.LowestSupportedVersion = ExtractEcFwVersions(
+                StringData, "LsFv:"
+            )  # Retrieve Lowest Supported EC Firmware Version
+            print(
+                "EC Firmware Version is {0}, lowest supported version: {1}".format(
+                    args.FwVersion, args.LowestSupportedVersion
+                )
+            )
 
     except FileNotFoundError:
-        print('EC Bin File does not exist: {0}.'.format(e))
+        print("EC Bin File does not exist: {0}.".format(e))
         sys.exit(1)
 
     except Exception as e:
-        print('Error occurred while reading from EC bin file: {0}.'.format(e))
+        print("Error occurred while reading from EC bin file: {0}.".format(e))
         sys.exit(1)
 
 
@@ -108,23 +163,23 @@ def get_python_version():
     python_version = None
     try:
         output = subprocess.check_output(["python", "--version"]).decode().strip()
-        python_version_l = output.split(' ')
-        python_version_no = int(python_version_l[1].split('.')[0])
+        python_version_l = output.split(" ")
+        python_version_no = int(python_version_l[1].split(".")[0])
 
         if python_version_no == 3:
             python_version = "python"
     except Exception:
-            print("'python --version' command failed to execute at command line")
+        print("'python --version' command failed to execute at command line")
 
     if python_version == None:
         try:
             output = subprocess.check_output(["python3", "--version"]).decode().strip()
-            python_version_op_l = output.split(' ')
-            python_version_no = int(python_version_op_l[1].split('.')[0])
+            python_version_op_l = output.split(" ")
+            python_version_no = int(python_version_op_l[1].split(".")[0])
             if python_version_no == 3:
                 python_version = "python3"
         except Exception:
-                print("'python3 --version' command failed to execute at command line")
+            print("'python3 --version' command failed to execute at command line")
 
     if python_version == None:
         print("ERROR 'python --version' and python")
@@ -137,18 +192,20 @@ def get_python_version():
 
 def GetSysFirmwareInfo(args):
     python_version = get_python_version()
-    commands = ['-GetFwVersionHex', '-GetLSFwVersionHex']
+    commands = ["-GetFwVersionHex", "-GetLSFwVersionHex"]
     SysBinPath = args.BinFile
     try:
         # Check if SysBinPath and SysFwVersion.exe path is valid
         if not os.path.exists(SysBinPath):
-            print('Invalid system firmware version file: {0}'.format(SysBinPath))
+            print("Invalid system firmware version file: {0}".format(SysBinPath))
             sys.exit(1)
 
         if platform.system() == "Linux":
-            SysFwExePath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'SYSFW_VERSION_program.py')
+            SysFwExePath = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "SYSFW_VERSION_program.py"
+            )
             if not os.path.exists(SysFwExePath):
-                print('SYSFW_VERSION_program.py not found at: {0}'.format(SysFwExePath))
+                print("SYSFW_VERSION_program.py not found at: {0}".format(SysFwExePath))
                 sys.exit(1)
 
             # Call SysFwVersion.exe tool to extract the firmware version and lowest
@@ -156,19 +213,31 @@ def GetSysFirmwareInfo(args):
             results = []
             for cmd in commands:
                 try:
-                    output = subprocess.check_output([python_version, SysFwExePath, cmd, SysBinPath]).decode().strip()
+                    output = (
+                        subprocess.check_output(
+                            [python_version, SysFwExePath, cmd, SysBinPath]
+                        )
+                        .decode()
+                        .strip()
+                    )
                     results.append(output)
                 except Exception as e:
-                    print('Failed to execute command:{0}. Error: {1}'.format(cmd, (e)))
+                    print("Failed to execute command:{0}. Error: {1}".format(cmd, (e)))
                     sys.exit(1)
 
             (args.FwVersion, args.LowestSupportedVersion) = (results[0], results[1])
-            print('Firmware Version is {0}, lowest supported version: {1}'.format(args.FwVersion, args.LowestSupportedVersion))
+            print(
+                "Firmware Version is {0}, lowest supported version: {1}".format(
+                    args.FwVersion, args.LowestSupportedVersion
+                )
+            )
 
         if platform.system() == "Windows":
-            SysFwExePath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'SYSFW_VERSION_program.py')
+            SysFwExePath = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "SYSFW_VERSION_program.py"
+            )
             if not os.path.exists(SysFwExePath):
-                print('SYSFW_VERSION_program.py not found at: {0}'.format(SysFwExePath))
+                print("SYSFW_VERSION_program.py not found at: {0}".format(SysFwExePath))
                 sys.exit(1)
 
             # Call SysFwVersion.exe tool to extract the firmware version and lowest
@@ -176,42 +245,53 @@ def GetSysFirmwareInfo(args):
             results = []
             for cmd in commands:
                 try:
-                    output = subprocess.check_output([python_version, SysFwExePath, cmd, SysBinPath]).decode().strip()
+                    output = (
+                        subprocess.check_output(
+                            [python_version, SysFwExePath, cmd, SysBinPath]
+                        )
+                        .decode()
+                        .strip()
+                    )
                     results.append(output)
                 except:
-                    print('Failed to execute command:{0}. Error: {1}'.format(cmd, (e)))
+                    print("Failed to execute command:{0}. Error: {1}".format(cmd, (e)))
                     print(traceback.format_exc())
 
             (args.FwVersion, args.LowestSupportedVersion) = (results[0], results[1])
-            print('Firmware Version is {0}, lowest supported version: {1}'.format(args.FwVersion, args.LowestSupportedVersion))
+            print(
+                "Firmware Version is {0}, lowest supported version: {1}".format(
+                    args.FwVersion, args.LowestSupportedVersion
+                )
+            )
 
     except subprocess.CalledProcessError as e:
-        print('Failed to extract firmware info from sys.bin: {0}'.format(e))
+        print("Failed to extract firmware info from sys.bin: {0}".format(e))
         sys.exit(1)
 
     except Exception as e:
-        print('Exception in GetFirmwareInfo(): {0}'.format(e))
+        print("Exception in GetFirmwareInfo(): {0}".format(e))
         sys.exit(1)
+
 
 def UpdateJsonFile(args):
     # Get the firmware version and lowest supported version by calling the
     # ExtractEcFwVersions()/SysFwVersion.exe and add it to the args list
-    FirmwareType   = args.FwType
-    EcFwString  = 'EC_FW'
-    SysFwString = 'SYS_FW'
+    FirmwareType = args.FwType
+    EcFwString = "EC_FW"
+    SysFwString = "SYS_FW"
     try:
-        if (FirmwareType == SysFwString):
+        if FirmwareType == SysFwString:
             GetSysFirmwareInfo(args)
-            print('GetSysFirmwareInfo(): {0}'.format(SysFwString))
-        elif (FirmwareType == EcFwString):
+            print("GetSysFirmwareInfo(): {0}".format(SysFwString))
+        elif FirmwareType == EcFwString:
             GetEcFirmwareInfo(args)
-            print('GetEcFirmwareInfo(): {0}'.format(EcFwString))
+            print("GetEcFirmwareInfo(): {0}".format(EcFwString))
         else:
-            print('Neither System nor EC FirmwareType: {0}'.format(FirmwareType))
+            print("Neither System nor EC FirmwareType: {0}".format(FirmwareType))
             sys.exit(1)
 
     except Exception as e:
-        print('Error occurred while reading from FirmwareType string: {0}.'.format(e))
+        print("Error occurred while reading from FirmwareType string: {0}.".format(e))
         sys.exit(1)
 
     JsonFile = args.JsonFile
@@ -227,36 +307,36 @@ def UpdateJsonFile(args):
         print("%s Not found" % (JsonFile))
 
     try:
-        with open(JsonFile, 'r') as f:
-            #loading the field values in json file without changing the order
+        with open(JsonFile, "r") as f:
+            # loading the field values in json file without changing the order
             data = json.load(f, object_pairs_hook=OrderedDict)
     except Exception as e:
-        print('Exception while opening JsonFile: {0}.'.format(e))
+        print("Exception while opening JsonFile: {0}.".format(e))
         sys.exit(1)
 
-    exception_list = ['JsonFile', 'BinFile' , 'FwType']
+    exception_list = ["JsonFile", "BinFile", "FwType"]
 
-    for i, payload in enumerate(data['Payloads']):
+    for i, payload in enumerate(data["Payloads"]):
         for key, value in args.__dict__.items():
             try:
                 if key in exception_list:
                     continue  # Skip the keys in the exception list
                 elif value and key in payload:
-                    data['Payloads'][i][key] = value
+                    data["Payloads"][i][key] = value
                 elif value:
-                    print('Key {0} not found in payload {1}'.format(key, i))
+                    print("Key {0} not found in payload {1}".format(key, i))
             except Exception as e:
-                print('Exception in UpdateJsonFile(): {0}'.format(e))
+                print("Exception in UpdateJsonFile(): {0}".format(e))
                 sys.exit(1)
 
     try:
-        with open(JsonFile, 'w') as f:
+        with open(JsonFile, "w") as f:
             json.dump(data, f, indent=4)
     except Exception as e:
-        print('Error occurred while writing to the JSON file: {0}.'.format(e))
+        print("Error occurred while writing to the JSON file: {0}.".format(e))
         sys.exit(1)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     args = ParseArguments()
     UpdateJsonFile(args)
-

--- a/uefi_capsule_generation/UpdateJsonParameters.py
+++ b/uefi_capsule_generation/UpdateJsonParameters.py
@@ -171,7 +171,7 @@ def get_python_version():
     except Exception:
         print("'python --version' command failed to execute at command line")
 
-    if python_version == None:
+    if python_version is None:
         try:
             output = subprocess.check_output(["python3", "--version"]).decode().strip()
             python_version_op_l = output.split(" ")
@@ -181,7 +181,7 @@ def get_python_version():
         except Exception:
             print("'python3 --version' command failed to execute at command line")
 
-    if python_version == None:
+    if python_version is None:
         print("ERROR 'python --version' and python")
         return None
 

--- a/uefi_capsule_generation/UpdateJsonParameters.py
+++ b/uefi_capsule_generation/UpdateJsonParameters.py
@@ -253,7 +253,7 @@ def GetSysFirmwareInfo(args):
                         .strip()
                     )
                     results.append(output)
-                except:
+                except Exception as e:
                     print("Failed to execute command:{0}. Error: {1}".format(cmd, (e)))
                     print(traceback.format_exc())
 

--- a/uefi_capsule_generation/UpdateJsonParameters.py
+++ b/uefi_capsule_generation/UpdateJsonParameters.py
@@ -12,11 +12,11 @@
 import argparse
 import json
 import os
+import platform
 import subprocess
 import sys
-from collections import OrderedDict
-import platform
 import traceback
+from collections import OrderedDict
 
 
 def ParseArguments():

--- a/uefi_capsule_generation/UpdateJsonParameters.py
+++ b/uefi_capsule_generation/UpdateJsonParameters.py
@@ -110,9 +110,6 @@ def ExtractEcFwVersions(StringData, SubString):
 
         offset = StringData.find(SubString)
         index = offset + len(SubString)
-        FwVerMain = (ord(StringData[index + 0]) - ord("0")) * 10 + (
-            ord(StringData[index + 1]) - ord("0")
-        )
         FwVerSub = (ord(StringData[index + 3]) - ord("0")) * 10 + (
             ord(StringData[index + 4]) - ord("0")
         )
@@ -150,7 +147,7 @@ def GetEcFirmwareInfo(args):
                 )
             )
 
-    except FileNotFoundError:
+    except FileNotFoundError as e:
         print("EC Bin File does not exist: {0}.".format(e))
         sys.exit(1)
 

--- a/uefi_capsule_generation/XmlFwEntryValidation.py
+++ b/uefi_capsule_generation/XmlFwEntryValidation.py
@@ -4,10 +4,11 @@
 # --------------------------------------------------------------------
 
 
-import FVCreation_header as FVC_h
-import FVCreation as FVC
-import uuid
 import ctypes
+import uuid
+
+import FVCreation as FVC
+import FVCreation_header as FVC_h
 
 
 def partition_fields_checking(raw_fwentry, raw_dev_path, meta_data_dev_path):

--- a/uefi_capsule_generation/XmlFwEntryValidation.py
+++ b/uefi_capsule_generation/XmlFwEntryValidation.py
@@ -1,4 +1,3 @@
-
 # --------------------------------------------------------------------
 # Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -22,7 +21,9 @@ def partition_fields_checking(raw_fwentry, raw_dev_path, meta_data_dev_path):
         print("Empty <PartitionName> tag is not allowed for partition operation")
         return False
     if raw_dev_path.PartitionTypeGUID is None:
-        print("Empty <PartitionTypeGuidName> tag is not allowed for partition operation")
+        print(
+            "Empty <PartitionTypeGuidName> tag is not allowed for partition operation"
+        )
         return False
     return True
 
@@ -35,7 +36,9 @@ def fat_fields_checking(raw_fwentry, raw_dev_path, meta_data_dev_path):
         print("Empty <DiskType> tag is not allowed for FAT file operation")
         return False
     if raw_dev_path.PartitionName is None and raw_dev_path.PartitionTypeGUID is None:
-        print("Enter <PartitionName> or <PartitionTypeGUID> is required for FAT file operation")
+        print(
+            "Enter <PartitionName> or <PartitionTypeGUID> is required for FAT file operation"
+        )
         return False
     if raw_dev_path.FileName is None:
         print("Empty <FileName> tag is not allowed for FAT file operation")
@@ -58,7 +61,9 @@ def delete_fat_fields_checking(raw_fwentry, raw_dev_path, meta_data_dev_path):
         print("Empty <DiskType> tag is not allowed for FAT file operation")
         return False
     if raw_dev_path.PartitionName is None and raw_dev_path.PartitionTypeGUID is None:
-        print("Empty <PartitionName> or <PartitionTypeGUID> is not allowed for FAT file operation")
+        print(
+            "Empty <PartitionName> or <PartitionTypeGUID> is not allowed for FAT file operation"
+        )
         return False
     if raw_dev_path.FileName is None:
         print("Empty <FileName> tag is not allowed for FAT file operation")
@@ -93,7 +98,9 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
     # Operation
     if raw_fwentry.Operation:
         if raw_fwentry.Operation.upper() in g_dynamic_var.dOperationTypeByString:
-            meta_data_fwentry.Operation = g_dynamic_var.dOperationTypeByString[raw_fwentry.Operation.upper()]
+            meta_data_fwentry.Operation = g_dynamic_var.dOperationTypeByString[
+                raw_fwentry.Operation.upper()
+            ]
         else:
             print(f"Operation {raw_fwentry.Operation} is not recognized")
             return False
@@ -101,7 +108,9 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
     # UpdateType
     if raw_fwentry.UpdateType:
         if raw_fwentry.UpdateType.upper() in g_dynamic_var.dUpdateTypeByString:
-            meta_data_fwentry.UpdateType = g_dynamic_var.dUpdateTypeByString[raw_fwentry.UpdateType.upper()]
+            meta_data_fwentry.UpdateType = g_dynamic_var.dUpdateTypeByString[
+                raw_fwentry.UpdateType.upper()
+            ]
             if meta_data_fwentry.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.FAT_FILE:
                 print("ERROR: <UpdateType> is not supported for FAT_FILE")
                 return False
@@ -116,7 +125,9 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
             return False
 
         if raw_fwentry.BackupType.upper() in g_dynamic_var.dBackupTypeByString:
-            meta_data_fwentry.BackupType = g_dynamic_var.dBackupTypeByString[raw_fwentry.BackupType.upper()]
+            meta_data_fwentry.BackupType = g_dynamic_var.dBackupTypeByString[
+                raw_fwentry.BackupType.upper()
+            ]
             if meta_data_fwentry.BackupType == FVC_h.FWENTRY_BACKUP_TYPE.FAT_FILE:
                 print("ERROR: <BackupType> is not supported for FAT_FILE")
                 return False
@@ -128,8 +139,13 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
     if g_dynamic_var.isMatchIdentifierInXML:
         meta_data_fwentry.Revision = FVC.SYS_FW_METADATA_REVISION
         if raw_fwentry.MatchIdentifier:
-            if len(raw_fwentry.MatchIdentifier) > FVC_h.GlobalStaticVariable.MATCH_IDENTIFIER_NAME_MAX_SIZE:
-                print(f"Error: More than {FVC_h.GlobalStaticVariable.MATCH_IDENTIFIER_NAME_MAX_SIZE} characters found in <MatchIdentifier>")
+            if (
+                len(raw_fwentry.MatchIdentifier)
+                > FVC_h.GlobalStaticVariable.MATCH_IDENTIFIER_NAME_MAX_SIZE
+            ):
+                print(
+                    f"Error: More than {FVC_h.GlobalStaticVariable.MATCH_IDENTIFIER_NAME_MAX_SIZE} characters found in <MatchIdentifier>"
+                )
                 return False
             meta_data_fwentry.MatchIdentifier = raw_fwentry.MatchIdentifier
 
@@ -140,9 +156,13 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
             return False
 
         if raw_fwentry.UpdatePath.DiskType.upper() in g_dynamic_var.dDiskTypeByString:
-            meta_data_fwentry.UpdatePath.DiskType = g_dynamic_var.dDiskTypeByString[raw_fwentry.UpdatePath.DiskType.upper()]
+            meta_data_fwentry.UpdatePath.DiskType = g_dynamic_var.dDiskTypeByString[
+                raw_fwentry.UpdatePath.DiskType.upper()
+            ]
         else:
-            print(f"Dest <DiskType> {raw_fwentry.UpdatePath.DiskType} is not recognized")
+            print(
+                f"Dest <DiskType> {raw_fwentry.UpdatePath.DiskType} is not recognized"
+            )
             return False
 
     # Dest PartitionName
@@ -150,13 +170,25 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
         if meta_data_fwentry.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.FWCLASS_GUID:
             print("ERROR: <Dest> is not supported for UPDATE_FWCLASS_GUID")
             return False
-        if len(raw_fwentry.UpdatePath.PartitionName) > FVC_h.GlobalStaticVariable.PARTITION_NAME_MAX_SIZE:
-            print(f"Error: More than {FVC_h.GlobalStaticVariable.PARTITION_NAME_MAX_SIZE} characters found in <PartitionName>")
+        if (
+            len(raw_fwentry.UpdatePath.PartitionName)
+            > FVC_h.GlobalStaticVariable.PARTITION_NAME_MAX_SIZE
+        ):
+            print(
+                f"Error: More than {FVC_h.GlobalStaticVariable.PARTITION_NAME_MAX_SIZE} characters found in <PartitionName>"
+            )
             return False
-        if raw_fwentry.UpdatePath.PartitionName == FVC_h.GlobalStaticVariable.PARTITION_NAME_SYSFW_VERSION:
-            print(f"Error: Partition name {FVC_h.GlobalStaticVariable.PARTITION_NAME_SYSFW_VERSION} is not allowed, Otherwise version conflict will occur when different binary is used")
+        if (
+            raw_fwentry.UpdatePath.PartitionName
+            == FVC_h.GlobalStaticVariable.PARTITION_NAME_SYSFW_VERSION
+        ):
+            print(
+                f"Error: Partition name {FVC_h.GlobalStaticVariable.PARTITION_NAME_SYSFW_VERSION} is not allowed, Otherwise version conflict will occur when different binary is used"
+            )
             return False
-        meta_data_fwentry.UpdatePath.PartitionName[:len(raw_fwentry.UpdatePath.PartitionName)] = bytearray(raw_fwentry.UpdatePath.PartitionName, 'utf-8')
+        meta_data_fwentry.UpdatePath.PartitionName[
+            : len(raw_fwentry.UpdatePath.PartitionName)
+        ] = bytearray(raw_fwentry.UpdatePath.PartitionName, "utf-8")
 
     # Dest PartitionTypeGuid
     if raw_fwentry.UpdatePath.PartitionTypeGUID:
@@ -164,11 +196,13 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
             print("ERROR: <Dest> is not supported for UPDATE_FWCLASS_GUID")
             return False
 
-        s_temp = raw_fwentry.UpdatePath.PartitionTypeGUID.strip('{}')
+        s_temp = raw_fwentry.UpdatePath.PartitionTypeGUID.strip("{}")
         if s_temp:
             try:
                 uuid_obj = uuid.UUID(s_temp)
-                meta_data_fwentry.UpdatePath.PartitionTypeGUID = (ctypes.c_byte * 16)(*uuid_obj.bytes)
+                meta_data_fwentry.UpdatePath.PartitionTypeGUID = (ctypes.c_byte * 16)(
+                    *uuid_obj.bytes
+                )
 
             except ValueError as e:
                 print(f"ERROR: Failure creating partitionTypeGuid(error: {e}).\n")
@@ -180,8 +214,13 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
             print("ERROR: <Dest> is not supported for UPDATE_FWCLASS_GUID")
             return False
 
-        if len(raw_fwentry.UpdatePath.FileName) > FVC_h.GlobalStaticVariable.FILE_NAME_MAX_SIZE:
-            print(f"Error: More than {FVC_h.GlobalStaticVariable.FILE_NAME_MAX_SIZE} characters found in <FileName>")
+        if (
+            len(raw_fwentry.UpdatePath.FileName)
+            > FVC_h.GlobalStaticVariable.FILE_NAME_MAX_SIZE
+        ):
+            print(
+                f"Error: More than {FVC_h.GlobalStaticVariable.FILE_NAME_MAX_SIZE} characters found in <FileName>"
+            )
             return False
         meta_data_fwentry.UpdatePath.FileName = raw_fwentry.UpdatePath.FileName
 
@@ -192,9 +231,13 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
             return False
 
         if raw_fwentry.BackupPath.DiskType.upper() in g_dynamic_var.dDiskTypeByString:
-            meta_data_fwentry.BackupPath.DiskType = g_dynamic_var.dDiskTypeByString[raw_fwentry.BackupPath.DiskType.upper()]
+            meta_data_fwentry.BackupPath.DiskType = g_dynamic_var.dDiskTypeByString[
+                raw_fwentry.BackupPath.DiskType.upper()
+            ]
         else:
-            print(f"Dest <DiskType> {raw_fwentry.BackupPath.DiskType} is not recognized")
+            print(
+                f"Dest <DiskType> {raw_fwentry.BackupPath.DiskType} is not recognized"
+            )
             return False
 
     # Backup PartitionName
@@ -203,13 +246,25 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
             print("ERROR: <Backup> is not supported for UPDATE_FWCLASS_GUID")
             return False
 
-        if len(raw_fwentry.BackupPath.PartitionName) > FVC_h.GlobalStaticVariable.PARTITION_NAME_MAX_SIZE:
-            print(f"Error: More than {FVC_h.GlobalStaticVariable.PARTITION_NAME_MAX_SIZE} characters found in <PartitionName>")
+        if (
+            len(raw_fwentry.BackupPath.PartitionName)
+            > FVC_h.GlobalStaticVariable.PARTITION_NAME_MAX_SIZE
+        ):
+            print(
+                f"Error: More than {FVC_h.GlobalStaticVariable.PARTITION_NAME_MAX_SIZE} characters found in <PartitionName>"
+            )
             return False
-        if raw_fwentry.BackupPath.PartitionName == FVC_h.GlobalStaticVariable.PARTITION_NAME_SYSFW_VERSION:
-            print(f"Error: Partition name {FVC_h.GlobalStaticVariable.PARTITION_NAME_SYSFW_VERSION} is not allowed, Otherwise version conflict will occur when different binary is used")
+        if (
+            raw_fwentry.BackupPath.PartitionName
+            == FVC_h.GlobalStaticVariable.PARTITION_NAME_SYSFW_VERSION
+        ):
+            print(
+                f"Error: Partition name {FVC_h.GlobalStaticVariable.PARTITION_NAME_SYSFW_VERSION} is not allowed, Otherwise version conflict will occur when different binary is used"
+            )
             return False
-        meta_data_fwentry.BackupPath.PartitionName[:len(raw_fwentry.BackupPath.PartitionName)] = bytearray(raw_fwentry.BackupPath.PartitionName, 'utf-8')
+        meta_data_fwentry.BackupPath.PartitionName[
+            : len(raw_fwentry.BackupPath.PartitionName)
+        ] = bytearray(raw_fwentry.BackupPath.PartitionName, "utf-8")
 
     # Backup PartitionTypeGuid
     if raw_fwentry.BackupPath.PartitionTypeGUID:
@@ -217,11 +272,13 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
             print("ERROR: <Backup> is not supported for UPDATE_FWCLASS_GUID")
             return False
 
-        s_temp = raw_fwentry.BackupPath.PartitionTypeGUID.strip('{}')
+        s_temp = raw_fwentry.BackupPath.PartitionTypeGUID.strip("{}")
         if s_temp:
             try:
                 uuid_obj = uuid.UUID(s_temp)
-                meta_data_fwentry.BackupPath.PartitionTypeGUID = (ctypes.c_byte * 16)(*uuid_obj.bytes)
+                meta_data_fwentry.BackupPath.PartitionTypeGUID = (ctypes.c_byte * 16)(
+                    *uuid_obj.bytes
+                )
             except ValueError as e:
                 print(f"ERROR: Failure creating partitionTypeGuid(error: {e}).\n")
                 return False
@@ -232,13 +289,17 @@ def fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var
             print("ERROR: <Backup> is not supported for UPDATE_FWCLASS_GUID")
             return False
 
-        if len(raw_fwentry.BackupPath.FileName) > FVC_h.GlobalStaticVariable.FILE_NAME_MAX_SIZE:
-            print(f"Error: More than {FVC_h.GlobalStaticVariable.FILE_NAME_MAX_SIZE} characters found in <FileName>")
+        if (
+            len(raw_fwentry.BackupPath.FileName)
+            > FVC_h.GlobalStaticVariable.FILE_NAME_MAX_SIZE
+        ):
+            print(
+                f"Error: More than {FVC_h.GlobalStaticVariable.FILE_NAME_MAX_SIZE} characters found in <FileName>"
+            )
             return False
         meta_data_fwentry.BackupPath.FileName = raw_fwentry.BackupPath.FileName
 
     return True
-
 
 
 def assign_file_guid_for_fw_entry(raw_fwentry, meta_data_fwentry, g_dynamic_var):
@@ -246,9 +307,18 @@ def assign_file_guid_for_fw_entry(raw_fwentry, meta_data_fwentry, g_dynamic_var)
     if meta_data_fwentry.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.FAT_FILE:
         return False
 
-    if (meta_data_fwentry.UpdateType in [FVC_h.FWENTRY_UPDATE_TYPE.DPP_OEM, FVC_h.FWENTRY_UPDATE_TYPE.DPP_QCOM, FVC_h.FWENTRY_UPDATE_TYPE.OPM_PRIV_KEY]):
-        if raw_fwentry.UpdatePath.FileName.upper() in g_dynamic_var.dFileGuidByDestDppItemFile:
-            s_temp_guid1 = g_dynamic_var.dFileGuidByDestDppItemFile[raw_fwentry.UpdatePath.FileName.upper()].strip('{}')
+    if meta_data_fwentry.UpdateType in [
+        FVC_h.FWENTRY_UPDATE_TYPE.DPP_OEM,
+        FVC_h.FWENTRY_UPDATE_TYPE.DPP_QCOM,
+        FVC_h.FWENTRY_UPDATE_TYPE.OPM_PRIV_KEY,
+    ]:
+        if (
+            raw_fwentry.UpdatePath.FileName.upper()
+            in g_dynamic_var.dFileGuidByDestDppItemFile
+        ):
+            s_temp_guid1 = g_dynamic_var.dFileGuidByDestDppItemFile[
+                raw_fwentry.UpdatePath.FileName.upper()
+            ].strip("{}")
             raw_fwentry.FileGuid = s_temp_guid1
             try:
                 meta_data_fwentry.FileGuid = uuid.UUID(s_temp_guid1)
@@ -268,12 +338,19 @@ def assign_file_guid_for_fw_entry(raw_fwentry, meta_data_fwentry, g_dynamic_var)
     raw_fwentry.FileGuid = meta_data_fwentry.FileGuid
     return True
 
+
 def fw_entry_fields_combination_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var):
     if meta_data_fwentry.Operation == FVC_h.FWENTRY_OPERATION_TYPE.UPDATE:
         if meta_data_fwentry.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.PARTITION:
-            if partition_fields_checking(raw_fwentry, raw_fwentry.UpdatePath, meta_data_fwentry.UpdatePath):
+            if partition_fields_checking(
+                raw_fwentry, raw_fwentry.UpdatePath, meta_data_fwentry.UpdatePath
+            ):
                 if meta_data_fwentry.BackupType == FVC_h.FWENTRY_BACKUP_TYPE.PARTITION:
-                    if partition_fields_checking(raw_fwentry, raw_fwentry.BackupPath, meta_data_fwentry.BackupPath):
+                    if partition_fields_checking(
+                        raw_fwentry,
+                        raw_fwentry.BackupPath,
+                        meta_data_fwentry.BackupPath,
+                    ):
                         print("Firmware entry validated\n")
                         return True
                     print("BackupPath partition validation failed")
@@ -291,12 +368,21 @@ def fw_entry_fields_combination_checking(raw_fwentry, meta_data_fwentry, g_dynam
         if meta_data_fwentry.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.FAT_FILE:
             return False
 
-        if meta_data_fwentry.UpdateType in [FVC_h.FWENTRY_UPDATE_TYPE.DPP_QCOM, FVC_h.FWENTRY_UPDATE_TYPE.DPP_OEM]:
-            if dpp_fields_checking(raw_fwentry, raw_fwentry.UpdatePath, meta_data_fwentry.UpdatePath):
+        if meta_data_fwentry.UpdateType in [
+            FVC_h.FWENTRY_UPDATE_TYPE.DPP_QCOM,
+            FVC_h.FWENTRY_UPDATE_TYPE.DPP_OEM,
+        ]:
+            if dpp_fields_checking(
+                raw_fwentry, raw_fwentry.UpdatePath, meta_data_fwentry.UpdatePath
+            ):
                 if meta_data_fwentry.BackupType == FVC_h.FWENTRY_BACKUP_TYPE.FAT_FILE:
                     return False
                 if meta_data_fwentry.BackupType == FVC_h.FWENTRY_BACKUP_TYPE.PARTITION:
-                    if partition_fields_checking(raw_fwentry, raw_fwentry.BackupPath, meta_data_fwentry.BackupPath):
+                    if partition_fields_checking(
+                        raw_fwentry,
+                        raw_fwentry.BackupPath,
+                        meta_data_fwentry.BackupPath,
+                    ):
                         print("Firmware entry validated\n")
                         return True
                     return False
@@ -304,11 +390,17 @@ def fw_entry_fields_combination_checking(raw_fwentry, meta_data_fwentry, g_dynam
             return False
 
         if meta_data_fwentry.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.OPM_PRIV_KEY:
-            if dpp_fields_checking(raw_fwentry, raw_fwentry.UpdatePath, meta_data_fwentry.UpdatePath):
+            if dpp_fields_checking(
+                raw_fwentry, raw_fwentry.UpdatePath, meta_data_fwentry.UpdatePath
+            ):
                 if meta_data_fwentry.BackupType == FVC_h.FWENTRY_BACKUP_TYPE.FAT_FILE:
                     return False
                 if meta_data_fwentry.BackupType == FVC_h.FWENTRY_BACKUP_TYPE.PARTITION:
-                    if partition_fields_checking(raw_fwentry, raw_fwentry.BackupPath, meta_data_fwentry.BackupPath):
+                    if partition_fields_checking(
+                        raw_fwentry,
+                        raw_fwentry.BackupPath,
+                        meta_data_fwentry.BackupPath,
+                    ):
                         print("Firmware entry validated\n")
                         return True
                     return False
@@ -326,7 +418,9 @@ def fw_entry_fields_combination_checking(raw_fwentry, meta_data_fwentry, g_dynam
 def fw_entry_validation(raw_fwentry, meta_data_fwentry, g_dynamic_var):
     print("Validating firmware entry...")
     print("============================")
-    print(f"               <FlashType>         = {g_dynamic_var.dFlashTypeByValue[g_dynamic_var.DeviceFlashType]}")
+    print(
+        f"               <FlashType>         = {g_dynamic_var.dFlashTypeByValue[g_dynamic_var.DeviceFlashType]}"
+    )
     print(f"               <InputBinary>       = {raw_fwentry.InputBinary}")
     print(f"               <Operation>         = {raw_fwentry.Operation}")
     print(f"               <UpdateType>        = {raw_fwentry.UpdateType}")
@@ -334,22 +428,34 @@ def fw_entry_validation(raw_fwentry, meta_data_fwentry, g_dynamic_var):
     if raw_fwentry.MatchIdentifier:
         print(f"               <MatchIdentifier>   = {raw_fwentry.MatchIdentifier}")
     print(f"    DestPath   <DiskType>          = {raw_fwentry.UpdatePath.DiskType}")
-    print(f"    DestPath   <PartitionName>     = {raw_fwentry.UpdatePath.PartitionName}")
-    print(f"    DestPath   <PartitionTypeGuid> = {raw_fwentry.UpdatePath.PartitionTypeGUID}")
+    print(
+        f"    DestPath   <PartitionName>     = {raw_fwentry.UpdatePath.PartitionName}"
+    )
+    print(
+        f"    DestPath   <PartitionTypeGuid> = {raw_fwentry.UpdatePath.PartitionTypeGUID}"
+    )
     print(f"    DestPath   <FileName>          = {raw_fwentry.UpdatePath.FileName}")
     print("\n")
     print(f"    BackupPath <DiskType>          = {raw_fwentry.BackupPath.DiskType}")
-    print(f"    BackupPath <PartitionName>     = {raw_fwentry.BackupPath.PartitionName}")
-    print(f"    BackupPath <PartitionTypeGuid> = {raw_fwentry.BackupPath.PartitionTypeGUID}")
+    print(
+        f"    BackupPath <PartitionName>     = {raw_fwentry.BackupPath.PartitionName}"
+    )
+    print(
+        f"    BackupPath <PartitionTypeGuid> = {raw_fwentry.BackupPath.PartitionTypeGUID}"
+    )
     print(f"    BackupPath <FileName>          = {raw_fwentry.BackupPath.FileName}")
 
-    if not fw_entry_fields_value_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var):
+    if not fw_entry_fields_value_checking(
+        raw_fwentry, meta_data_fwentry, g_dynamic_var
+    ):
         return False
 
     if not assign_file_guid_for_fw_entry(raw_fwentry, meta_data_fwentry, g_dynamic_var):
         return False
 
-    if not fw_entry_fields_combination_checking(raw_fwentry, meta_data_fwentry, g_dynamic_var):
+    if not fw_entry_fields_combination_checking(
+        raw_fwentry, meta_data_fwentry, g_dynamic_var
+    ):
         return False
 
     return True
@@ -365,7 +471,9 @@ def fw_entry_list_validation_main(g_dynamic_var):
         m_fw_entry.UpdatePath = FVC_h.FWENTRY_DEVICE_PATH(0x0)
         m_fw_entry.BackupPath = FVC_h.FWENTRY_DEVICE_PATH(0x0)
         if g_dynamic_var.isMatchIdentifierInXML:
-            m_fw_entry.MatchIdentifier = ['\0'] * FVC_h.GlobalStaticVariable.MATCH_IDENTIFIER_NAME_MAX_SIZE
+            m_fw_entry.MatchIdentifier = [
+                "\0"
+            ] * FVC_h.GlobalStaticVariable.MATCH_IDENTIFIER_NAME_MAX_SIZE
 
         if fw_entry_validation(raw_fw_entry_temp, m_fw_entry, g_dynamic_var):
             if m_fw_entry.Operation != FVC_h.FWENTRY_OPERATION_TYPE.IGNORE:
@@ -380,13 +488,31 @@ def fw_entry_list_validation_main(g_dynamic_var):
     for i in range(len(g_dynamic_var.QpayloadFwEntryList)):
         m_fw_entry = g_dynamic_var.QpayloadFwEntryList[i]
         if m_fw_entry.UpdateType != FVC_h.FWENTRY_UPDATE_TYPE.FWCLASS_GUID:
-            if (m_fw_entry.UpdateType not in [FVC_h.FWENTRY_UPDATE_TYPE.DPP_QCOM, FVC_h.FWENTRY_UPDATE_TYPE.DPP_OEM, FVC_h.FWENTRY_UPDATE_TYPE.OPM_PRIV_KEY]):
-                if g_dynamic_var.DeviceFlashType not in g_dynamic_var.dFlashTypeByDiskType[FVC_h.FWENTRY_DISK_TYPE(m_fw_entry.UpdatePath.DiskType)]:
-                    print(f"ERROR1: DiskType {g_dynamic_var.dDiskTypeByValue[FVC_h.FWENTRY_DISK_TYPE(m_fw_entry.UpdatePath.DiskType)]} can't be used on a {g_dynamic_var.dFlashTypeByValue[g_dynamic_var.DeviceFlashType]} device.")
+            if m_fw_entry.UpdateType not in [
+                FVC_h.FWENTRY_UPDATE_TYPE.DPP_QCOM,
+                FVC_h.FWENTRY_UPDATE_TYPE.DPP_OEM,
+                FVC_h.FWENTRY_UPDATE_TYPE.OPM_PRIV_KEY,
+            ]:
+                if (
+                    g_dynamic_var.DeviceFlashType
+                    not in g_dynamic_var.dFlashTypeByDiskType[
+                        FVC_h.FWENTRY_DISK_TYPE(m_fw_entry.UpdatePath.DiskType)
+                    ]
+                ):
+                    print(
+                        f"ERROR1: DiskType {g_dynamic_var.dDiskTypeByValue[FVC_h.FWENTRY_DISK_TYPE(m_fw_entry.UpdatePath.DiskType)]} can't be used on a {g_dynamic_var.dFlashTypeByValue[g_dynamic_var.DeviceFlashType]} device."
+                    )
                     return False
 
-            if g_dynamic_var.DeviceFlashType not in g_dynamic_var.dFlashTypeByDiskType[FVC_h.FWENTRY_DISK_TYPE(m_fw_entry.BackupPath.DiskType)]:
-                print(f"ERROR2: DiskType {g_dynamic_var.dDiskTypeByValue[FVC_h.FWENTRY_DISK_TYPE(m_fw_entry.BackupPath.DiskType)]} can't be used on a {g_dynamic_var.dFlashTypeByValue[g_dynamic_var.DeviceFlashType]} device.")
+            if (
+                g_dynamic_var.DeviceFlashType
+                not in g_dynamic_var.dFlashTypeByDiskType[
+                    FVC_h.FWENTRY_DISK_TYPE(m_fw_entry.BackupPath.DiskType)
+                ]
+            ):
+                print(
+                    f"ERROR2: DiskType {g_dynamic_var.dDiskTypeByValue[FVC_h.FWENTRY_DISK_TYPE(m_fw_entry.BackupPath.DiskType)]} can't be used on a {g_dynamic_var.dFlashTypeByValue[g_dynamic_var.DeviceFlashType]} device."
+                )
                 return False
 
     # QCOM Dpp Item Name exclusive checking
@@ -395,14 +521,16 @@ def fw_entry_list_validation_main(g_dynamic_var):
         m_fw_entry_base = g_dynamic_var.QpayloadFwEntryList[i]
 
         if m_fw_entry_base.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.DPP_QCOM:
-            base_file_name = ''.join(m_fw_entry_base.UpdatePath.FileName)
+            base_file_name = "".join(m_fw_entry_base.UpdatePath.FileName)
 
             for j in range(i + 1, len(g_dynamic_var.QpayloadFwEntryList)):
                 m_fw_entry_target = g_dynamic_var.QpayloadFwEntryList[j]
                 if m_fw_entry_target.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.DPP_QCOM:
-                    target_file_name = ''.join(m_fw_entry_target.UpdatePath.FileName)
+                    target_file_name = "".join(m_fw_entry_target.UpdatePath.FileName)
                     if base_file_name == target_file_name:
-                        print("ERROR: duplicated QCOM type DPP items found in the list.")
+                        print(
+                            "ERROR: duplicated QCOM type DPP items found in the list."
+                        )
                         return False
 
     # OEM Dpp Item Name exclusive checking
@@ -411,12 +539,12 @@ def fw_entry_list_validation_main(g_dynamic_var):
         m_fw_entry_base = g_dynamic_var.QpayloadFwEntryList[i]
 
         if m_fw_entry_base.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.DPP_OEM:
-            base_file_name = ''.join(m_fw_entry_base.UpdatePath.FileName)
+            base_file_name = "".join(m_fw_entry_base.UpdatePath.FileName)
 
             for j in range(i + 1, len(g_dynamic_var.QpayloadFwEntryList)):
                 m_fw_entry_target = g_dynamic_var.QpayloadFwEntryList[j]
                 if m_fw_entry_target.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.DPP_OEM:
-                    target_file_name = ''.join(m_fw_entry_target.UpdatePath.FileName)
+                    target_file_name = "".join(m_fw_entry_target.UpdatePath.FileName)
                     if base_file_name == target_file_name:
                         print("ERROR: duplicated OEM type DPP items found in the list.")
                         return False
@@ -427,74 +555,138 @@ def fw_entry_list_validation_main(g_dynamic_var):
         m_fw_entry_base = g_dynamic_var.QpayloadFwEntryList[i]
 
         if m_fw_entry_base.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.PARTITION:
-            base_update_part_name = ''.join(chr(b) for b in m_fw_entry_base.UpdatePath.PartitionName)
-            base_backup_part_name = ''.join(chr(b) for b in m_fw_entry_base.BackupPath.PartitionName)
+            base_update_part_name = "".join(
+                chr(b) for b in m_fw_entry_base.UpdatePath.PartitionName
+            )
+            base_backup_part_name = "".join(
+                chr(b) for b in m_fw_entry_base.BackupPath.PartitionName
+            )
 
             # Case 1: BaseFwEntry's updatePath VS BaseFwEntry's BackupPath.
-            if (m_fw_entry_base.UpdatePath.DiskType == m_fw_entry_base.BackupPath.DiskType and
-                m_fw_entry_base.UpdatePath.PartitionTypeGUID == m_fw_entry_base.BackupPath.PartitionTypeGUID and
-                base_update_part_name == base_backup_part_name):
-                print("ERROR: same partition update path and backup path found in the same entry.")
+            if (
+                m_fw_entry_base.UpdatePath.DiskType
+                == m_fw_entry_base.BackupPath.DiskType
+                and m_fw_entry_base.UpdatePath.PartitionTypeGUID
+                == m_fw_entry_base.BackupPath.PartitionTypeGUID
+                and base_update_part_name == base_backup_part_name
+            ):
+                print(
+                    "ERROR: same partition update path and backup path found in the same entry."
+                )
                 return False
 
             for j in range(i + 1, len(g_dynamic_var.QpayloadFwEntryList)):
                 m_fw_entry_target = g_dynamic_var.QpayloadFwEntryList[j]
                 if m_fw_entry_target.UpdateType == FVC_h.FWENTRY_UPDATE_TYPE.PARTITION:
-                    target_update_part_name = ''.join(chr(b) for b in m_fw_entry_target.UpdatePath.PartitionName)
-                    target_backup_part_name = ''.join(chr(b) for b in m_fw_entry_target.BackupPath.PartitionName)
+                    target_update_part_name = "".join(
+                        chr(b) for b in m_fw_entry_target.UpdatePath.PartitionName
+                    )
+                    target_backup_part_name = "".join(
+                        chr(b) for b in m_fw_entry_target.BackupPath.PartitionName
+                    )
 
                     if g_dynamic_var.isMatchIdentifierInXML:
                         if any(m_fw_entry_base.MatchIdentifier):
-                            base_match_identifier = ''.join(m_fw_entry_base.MatchIdentifier)
+                            base_match_identifier = "".join(
+                                m_fw_entry_base.MatchIdentifier
+                            )
                         if any(m_fw_entry_target.MatchIdentifier):
-                            target_match_identifier = ''.join(m_fw_entry_target.MatchIdentifier)
+                            target_match_identifier = "".join(
+                                m_fw_entry_target.MatchIdentifier
+                            )
 
                     # Case 2: BaseFwEntry's updatePath VS TargetFwEntry's UpdatePath
-                    if (m_fw_entry_base.UpdatePath.DiskType == m_fw_entry_target.UpdatePath.DiskType and
-                        m_fw_entry_base.UpdatePath.PartitionTypeGUID == m_fw_entry_target.UpdatePath.PartitionTypeGUID and
-                        base_update_part_name == target_update_part_name):
+                    if (
+                        m_fw_entry_base.UpdatePath.DiskType
+                        == m_fw_entry_target.UpdatePath.DiskType
+                        and m_fw_entry_base.UpdatePath.PartitionTypeGUID
+                        == m_fw_entry_target.UpdatePath.PartitionTypeGUID
+                        and base_update_part_name == target_update_part_name
+                    ):
                         if not base_match_identifier or not target_match_identifier:
-                            print("ERROR: same partition update path found in the list.")
+                            print(
+                                "ERROR: same partition update path found in the list."
+                            )
                             return False
                         elif base_match_identifier == target_match_identifier:
-                            print("ERROR: same partition update path with same match identifier found in the list.")
+                            print(
+                                "ERROR: same partition update path with same match identifier found in the list."
+                            )
                             return False
                         elif base_match_identifier != target_match_identifier:
-                            xml_entry_base = find_xml_raw_fw_entry_node(m_fw_entry_base, g_dynamic_var)
-                            xml_entry_target = find_xml_raw_fw_entry_node(m_fw_entry_target, g_dynamic_var)
-                            if xml_entry_base.InputBinary == xml_entry_target.InputBinary:
-                                print("ERROR: same partition update path with same input binary found in the list.")
+                            xml_entry_base = find_xml_raw_fw_entry_node(
+                                m_fw_entry_base, g_dynamic_var
+                            )
+                            xml_entry_target = find_xml_raw_fw_entry_node(
+                                m_fw_entry_target, g_dynamic_var
+                            )
+                            if (
+                                xml_entry_base.InputBinary
+                                == xml_entry_target.InputBinary
+                            ):
+                                print(
+                                    "ERROR: same partition update path with same input binary found in the list."
+                                )
                                 return False
 
                     # Case 3: BaseFwEntry's updatePath VS TargetFwEntry's BackupPath
-                    if (m_fw_entry_base.UpdatePath.DiskType == m_fw_entry_target.BackupPath.DiskType and
-                        m_fw_entry_base.UpdatePath.PartitionTypeGUID == m_fw_entry_target.BackupPath.PartitionTypeGUID and
-                        base_update_part_name == target_backup_part_name):
-                        print("ERROR: same partition update path and backup path found in the list.")
+                    if (
+                        m_fw_entry_base.UpdatePath.DiskType
+                        == m_fw_entry_target.BackupPath.DiskType
+                        and m_fw_entry_base.UpdatePath.PartitionTypeGUID
+                        == m_fw_entry_target.BackupPath.PartitionTypeGUID
+                        and base_update_part_name == target_backup_part_name
+                    ):
+                        print(
+                            "ERROR: same partition update path and backup path found in the list."
+                        )
                         return False
 
                     # Case 4: BaseFwEntry's BackupPath VS TargetFwEntry's UpdatePath
-                    if (m_fw_entry_base.BackupPath.DiskType == m_fw_entry_target.UpdatePath.DiskType and
-                        m_fw_entry_base.BackupPath.PartitionTypeGUID == m_fw_entry_target.UpdatePath.PartitionTypeGUID and
-                        base_backup_part_name == target_update_part_name):
-                        print("ERROR: same partition update path and backup path found in the list.")
+                    if (
+                        m_fw_entry_base.BackupPath.DiskType
+                        == m_fw_entry_target.UpdatePath.DiskType
+                        and m_fw_entry_base.BackupPath.PartitionTypeGUID
+                        == m_fw_entry_target.UpdatePath.PartitionTypeGUID
+                        and base_backup_part_name == target_update_part_name
+                    ):
+                        print(
+                            "ERROR: same partition update path and backup path found in the list."
+                        )
                         return False
 
                     # Case 5: BaseFwEntry's BackupPath VS TargetFwEntry's BackupPath
-                    if (m_fw_entry_base.BackupPath.DiskType == m_fw_entry_target.BackupPath.DiskType and
-                        m_fw_entry_base.BackupPath.PartitionTypeGUID == m_fw_entry_target.BackupPath.PartitionTypeGUID and
-                        base_backup_part_name == target_backup_part_name):
+                    if (
+                        m_fw_entry_base.BackupPath.DiskType
+                        == m_fw_entry_target.BackupPath.DiskType
+                        and m_fw_entry_base.BackupPath.PartitionTypeGUID
+                        == m_fw_entry_target.BackupPath.PartitionTypeGUID
+                        and base_backup_part_name == target_backup_part_name
+                    ):
                         if not base_match_identifier or not target_match_identifier:
-                            print("ERROR: same partition backup path found in the list.")
+                            print(
+                                "ERROR: same partition backup path found in the list."
+                            )
                             return False
                         elif base_match_identifier == target_match_identifier:
-                            print("ERROR: same partition backup path with same match identifier found in the list.")
+                            print(
+                                "ERROR: same partition backup path with same match identifier found in the list."
+                            )
                             return False
                         elif base_match_identifier != target_match_identifier:
-                            xml_entry_base = find_xml_raw_fw_entry_node(m_fw_entry_base, g_dynamic_var)
-                            xml_entry_target = find_xml_raw_fw_entry_node(m_fw_entry_target, g_dynamic_var)
-                            if xml_entry_base.InputBinary == xml_entry_target.InputBinary:
-                                print("ERROR: same partition backup path with same input binary found in the list.")
+                            xml_entry_base = find_xml_raw_fw_entry_node(
+                                m_fw_entry_base, g_dynamic_var
+                            )
+                            xml_entry_target = find_xml_raw_fw_entry_node(
+                                m_fw_entry_target, g_dynamic_var
+                            )
+                            if (
+                                xml_entry_base.InputBinary
+                                == xml_entry_target.InputBinary
+                            ):
+                                print(
+                                    "ERROR: same partition backup path with same input binary found in the list."
+                                )
                                 return False
 
     # Fat device path exclusive checking

--- a/uefi_capsule_generation/XmlParser.py
+++ b/uefi_capsule_generation/XmlParser.py
@@ -1,4 +1,3 @@
-
 # --------------------------------------------------------------------
 # Copyright (c) 2024 Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
@@ -12,8 +11,8 @@ import traceback
 import re
 
 
-def print_all_level_d(d, indent = 0, log_file_obj = None):
-    '''
+def print_all_level_d(d, indent=0, log_file_obj=None):
+    """
     About:
         Function to print in console, a nested dict with indentation for easy reading
         For debugging
@@ -24,7 +23,7 @@ def print_all_level_d(d, indent = 0, log_file_obj = None):
 
     Return:
         None
-    '''
+    """
     if not d:
         return
     if isinstance(d, list):
@@ -56,14 +55,17 @@ def print_all_level_d(d, indent = 0, log_file_obj = None):
         return
 
     for x in d:
-
-        if isinstance(d[x], OrderedDict) or isinstance(d[x], dict) or isinstance(d[x], list):
+        if (
+            isinstance(d[x], OrderedDict)
+            or isinstance(d[x], dict)
+            or isinstance(d[x], list)
+        ):
             s = ""
             for i in range(indent):
                 print(" ", end="")
                 s += " "
             print(x + " : ")
-            print_all_level_d(d[x], indent+4, log_file_obj)
+            print_all_level_d(d[x], indent + 4, log_file_obj)
 
         else:
             s = ""
@@ -99,17 +101,13 @@ def parse_input_xml(s_xml_file, s_breaking_change_number, g_dynamic_var):
         tree = ET.parse(s_xml_file)
         root = tree.getroot()
 
-
-
     except Exception:
         print(traceback.format_exc())
         return False
 
     result_dict = xml_to_dict(root)
 
-
     # print_all_level_d(result_dict)
-
 
     # print("\n\n\nin custom code:")
     if isinstance(result_dict["FwEntry"], OrderedDict):
@@ -128,12 +126,13 @@ def parse_input_xml(s_xml_file, s_breaking_change_number, g_dynamic_var):
         raw_fw_item.UpdatePath.PartitionTypeGUID = fw_entry["Dest"]["PartitionTypeGUID"]
         raw_fw_item.BackupPath.DiskType = fw_entry["Backup"]["DiskType"]
         raw_fw_item.BackupPath.PartitionName = fw_entry["Backup"]["PartitionName"]
-        raw_fw_item.BackupPath.PartitionTypeGUID = fw_entry["Backup"]["PartitionTypeGUID"]
+        raw_fw_item.BackupPath.PartitionTypeGUID = fw_entry["Backup"][
+            "PartitionTypeGUID"
+        ]
 
         g_dynamic_var.XmlRawFwEntryList.append(raw_fw_item)
 
     # print("\n\n\n*******************\n")
-
 
     metadata_items = root.findall(".//Metadata")
 
@@ -164,7 +163,9 @@ def parse_input_xml(s_xml_file, s_breaking_change_number, g_dynamic_var):
             return False
 
         if not re.match("^[0-9]+$", s_brk_chg_num):
-            print("ERROR: Invalid BreakingChangeNumber in the XML file. BreakingChangeNumber should only contain numbers.")
+            print(
+                "ERROR: Invalid BreakingChangeNumber in the XML file. BreakingChangeNumber should only contain numbers."
+            )
             return False
         else:
             s_breaking_change_number = s_brk_chg_num
@@ -174,9 +175,13 @@ def parse_input_xml(s_xml_file, s_breaking_change_number, g_dynamic_var):
             return False
 
         if s_flash_type_in.upper() not in g_dynamic_var.dFlashTypeByString:
-            print("ERROR: Invalid FlashType in the XML file. FlashType should only be UFS or EMMC.")
+            print(
+                "ERROR: Invalid FlashType in the XML file. FlashType should only be UFS or EMMC."
+            )
             return False
         else:
-            g_dynamic_var.DeviceFlashType = g_dynamic_var.dFlashTypeByString[s_flash_type_in.upper()]
+            g_dynamic_var.DeviceFlashType = g_dynamic_var.dFlashTypeByString[
+                s_flash_type_in.upper()
+            ]
 
     return True

--- a/uefi_capsule_generation/XmlParser.py
+++ b/uefi_capsule_generation/XmlParser.py
@@ -4,11 +4,12 @@
 # --------------------------------------------------------------------
 
 
-import xml.etree.ElementTree as ET
-import FVCreation_header as FVC_h
-from collections import OrderedDict
-import traceback
 import re
+import traceback
+import xml.etree.ElementTree as ET
+from collections import OrderedDict
+
+import FVCreation_header as FVC_h
 
 
 def print_all_level_d(d, indent=0, log_file_obj=None):

--- a/uefi_capsule_generation/XmlParser.py
+++ b/uefi_capsule_generation/XmlParser.py
@@ -167,8 +167,6 @@ def parse_input_xml(s_xml_file, s_breaking_change_number, g_dynamic_var):
                 "ERROR: Invalid BreakingChangeNumber in the XML file. BreakingChangeNumber should only contain numbers."
             )
             return False
-        else:
-            s_breaking_change_number = s_brk_chg_num
 
         if not media_found:
             print("Warning: MetaData does not contain FlashType element.")

--- a/uefi_capsule_generation/capsule_creator.py
+++ b/uefi_capsule_generation/capsule_creator.py
@@ -7,62 +7,104 @@ import os
 import subprocess
 import argparse
 
+
 def run_command(command, fail_on_error=False):
     try:
         result = subprocess.run(command, shell=True, capture_output=True, text=True)
         if result.returncode != 0:
-            raise Exception(f"Command failed with return code {result.returncode}: {result.stderr}")
+            raise Exception(
+                f"Command failed with return code {result.returncode}: {result.stderr}"
+            )
         print(result.stdout)
     except Exception as e:
         print(f"Error: {str(e)}")
         exit(1)
+
 
 def main(args):
 
     if args.setup:
         run_command("python3 capsule_setup.py", fail_on_error=True)
     # Step 1: Generate SYSFW_VERSION.bin
-    run_command(f"python3 SYSFW_VERSION_program.py -Gen -FwVer {args.fwver} -LFwVer {args.lfwver} -O SYSFW_VERSION.bin")
+    run_command(
+        f"python3 SYSFW_VERSION_program.py -Gen -FwVer {args.fwver} -LFwVer {args.lfwver} -O SYSFW_VERSION.bin"
+    )
 
     # Step 2: Create FvUpdate.xml
-    ptool_path_arg = f'--ptool-path {args.ptool_path}' if args.ptool_path else ''
-    run_command(f'python3 UpdateFvXml.py -S {args.S} -T {args.t} {ptool_path_arg}')
+    ptool_path_arg = f"--ptool-path {args.ptool_path}" if args.ptool_path else ""
+    run_command(f"python3 UpdateFvXml.py -S {args.S} -T {args.t} {ptool_path_arg}")
 
     # Step 3: Create firmware volume
-    edk2_path_arg = f'--edk2-path {args.edk2_path}' if args.edk2_path else ''
-    run_command(f'python3 FVCreation.py firmware.fv "-FvType" "SYS_FW" "FvUpdate.xml" SYSFW_VERSION.bin {args.images} {edk2_path_arg}')
+    edk2_path_arg = f"--edk2-path {args.edk2_path}" if args.edk2_path else ""
+    run_command(
+        f'python3 FVCreation.py firmware.fv "-FvType" "SYS_FW" "FvUpdate.xml" SYSFW_VERSION.bin {args.images} {edk2_path_arg}'
+    )
 
     # Step 4: Update JSON parameters
-    run_command(f'python3 UpdateJsonParameters.py -j {args.config} -f SYS_FW -b SYSFW_VERSION.bin -pf firmware.fv -p {args.p} -x {args.x} -oc {args.oc} -g {args.guid}')
+    run_command(
+        f"python3 UpdateJsonParameters.py -j {args.config} -f SYS_FW -b SYSFW_VERSION.bin -pf firmware.fv -p {args.p} -x {args.x} -oc {args.oc} -g {args.guid}"
+    )
 
     # Step 5: Generate capsule
     if args.edk2_path:
-        generate_capsule = os.path.join(args.edk2_path, 'BaseTools', 'Source', 'Python', 'Capsule', 'GenerateCapsule.py')
-        pythonpath = os.path.join(args.edk2_path, 'BaseTools', 'Source', 'Python')
-        run_command(f'PYTHONPATH={pythonpath} python3 {generate_capsule} -e -j {args.config} -o {args.capsule} --capflag PersistAcrossReset -v')
+        generate_capsule = os.path.join(
+            args.edk2_path,
+            "BaseTools",
+            "Source",
+            "Python",
+            "Capsule",
+            "GenerateCapsule.py",
+        )
+        pythonpath = os.path.join(args.edk2_path, "BaseTools", "Source", "Python")
+        run_command(
+            f"PYTHONPATH={pythonpath} python3 {generate_capsule} -e -j {args.config} -o {args.capsule} --capflag PersistAcrossReset -v"
+        )
     else:
-        run_command(f'python3 GenerateCapsule.py -e -j {args.config} -o {args.capsule} --capflag PersistAcrossReset -v')
+        run_command(
+            f"python3 GenerateCapsule.py -e -j {args.config} -o {args.capsule} --capflag PersistAcrossReset -v"
+        )
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Combined script for Capsule generation")
-    parser.add_argument('-fwver', required=True, help='Firmware version')
-    parser.add_argument('-lfwver', required=True, help='Lowest supported firmware version')
-    parser.add_argument('-config', required=True, help='Configuration JSON file')
-    parser.add_argument('-p', required=True, help='Certificate file')
-    parser.add_argument('-x', required=True, help='Root certificate file')
-    parser.add_argument('-oc', required=True, help='Sub certificate file')
-    parser.add_argument('-guid', required=True, help='FMP GUID')
-    parser.add_argument('-capsule', required=True, help='Output capsule file name')
-    parser.add_argument('-images', required=True, help='Images directory')
-    parser.add_argument('-setup', action='store_true', help='Run capsule setup script')
-    parser.add_argument('--edk2-path', dest='edk2_path', default=None,
-                        help='Path to an existing edk2 directory with built GenFfs/GenFv tools; '
-                             'when provided, capsule_setup.py does not need to be run')
-    parser.add_argument('--ptool-path', dest='ptool_path', default=None,
-                        help='Path to an existing qcom-ptool directory; '
-                             'when provided, the repository is not cloned')
-    parser.add_argument("-S", "--StorageType", choices=["UFS", "EMMC"], required=True, help="Specify storage type: UFS or EMMC")
-    parser.add_argument("-T", "--target", required=True, help="Specify target platform (e.g., QCS6490)")
+    parser = argparse.ArgumentParser(
+        description="Combined script for Capsule generation"
+    )
+    parser.add_argument("-fwver", required=True, help="Firmware version")
+    parser.add_argument(
+        "-lfwver", required=True, help="Lowest supported firmware version"
+    )
+    parser.add_argument("-config", required=True, help="Configuration JSON file")
+    parser.add_argument("-p", required=True, help="Certificate file")
+    parser.add_argument("-x", required=True, help="Root certificate file")
+    parser.add_argument("-oc", required=True, help="Sub certificate file")
+    parser.add_argument("-guid", required=True, help="FMP GUID")
+    parser.add_argument("-capsule", required=True, help="Output capsule file name")
+    parser.add_argument("-images", required=True, help="Images directory")
+    parser.add_argument("-setup", action="store_true", help="Run capsule setup script")
+    parser.add_argument(
+        "--edk2-path",
+        dest="edk2_path",
+        default=None,
+        help="Path to an existing edk2 directory with built GenFfs/GenFv tools; "
+        "when provided, capsule_setup.py does not need to be run",
+    )
+    parser.add_argument(
+        "--ptool-path",
+        dest="ptool_path",
+        default=None,
+        help="Path to an existing qcom-ptool directory; "
+        "when provided, the repository is not cloned",
+    )
+    parser.add_argument(
+        "-S",
+        "--StorageType",
+        choices=["UFS", "EMMC"],
+        required=True,
+        help="Specify storage type: UFS or EMMC",
+    )
+    parser.add_argument(
+        "-T", "--target", required=True, help="Specify target platform (e.g., QCS6490)"
+    )
 
     args = parser.parse_args()
     main(args)

--- a/uefi_capsule_generation/capsule_creator.py
+++ b/uefi_capsule_generation/capsule_creator.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 # --------------------------------------------------------------------
 
+import argparse
 import os
 import subprocess
-import argparse
 
 
 def run_command(command, fail_on_error=False):

--- a/uefi_capsule_generation/capsule_setup.py
+++ b/uefi_capsule_generation/capsule_setup.py
@@ -128,7 +128,7 @@ def sync_edk2_linux(edk2_git_repo_sync_url, edk2_dir_path):
         print(f"Error cloning repository: {e}")
         return "Error cloning repository"
 
-    if update_edk2_submodules_linux(edk2_dir_path) != True:
+    if update_edk2_submodules_linux(edk2_dir_path) is not True:
         print("Failed to sync submodules")
         return "Failed to sync submodules"
 
@@ -141,12 +141,12 @@ def sync_and_build_edk2_linux(edk2_dir_path, c_dir):
         edk2_get_repo_sync_stats = sync_edk2_linux(
             edk2_git_repo_sync_url, edk2_dir_path
         )
-        if edk2_get_repo_sync_stats != True:
+        if edk2_get_repo_sync_stats is not True:
             return edk2_get_repo_sync_stats
 
         edk2_build_stats = run_make_command_linux(c_dir)
 
-        if edk2_build_stats != True:
+        if edk2_build_stats is not True:
             return edk2_build_stats
 
     return True
@@ -253,7 +253,7 @@ def sync_and_build_edk2_win(clone_dir, full_build):
 
     if platform.system() == "Windows":
         edk2_get_repo_sync_stats = sync_edk2_win(clone_dir)
-        if edk2_get_repo_sync_stats != True:
+        if edk2_get_repo_sync_stats is not True:
             return edk2_get_repo_sync_stats
 
 
@@ -519,29 +519,29 @@ def print_stats(
         "------------------------------------"
     )
 
-    if sync_generate_capsule_py_stats == True:
+    if sync_generate_capsule_py_stats is True:
         print("Downloaded GenerateCapsule.py successfully")
     else:
         print(
             f"Downloading GenerateCapsule.py failed: {sync_generate_capsule_py_stats}"
         )
 
-    if sync_and_build_edk2_win_stats == True:
+    if sync_and_build_edk2_win_stats is True:
         print("Downloaded and Built EDK2 successfully")
     else:
         print(f"Downloading and Building EDK2 failed: {sync_and_build_edk2_win_stats}")
 
-    if copy_GenFfs_win_stats == True:
+    if copy_GenFfs_win_stats is True:
         print("Copied GenFfs successfully")
     else:
         print(f"Copying GenFfs failed: {copy_GenFfs_win_stats}")
 
-    if copy_GenFv_win_stats == True:
+    if copy_GenFv_win_stats is True:
         print("Copied GenFv successfully")
     else:
         print(f"Copying GenFv failed: {copy_GenFv_win_stats}")
 
-    if sync_common_dir_stats == True:
+    if sync_common_dir_stats is True:
         print("Downloaded Common directory successfully")
     else:
         print(f"Downloading Common directory failed: {sync_common_dir_stats}")

--- a/uefi_capsule_generation/capsule_setup.py
+++ b/uefi_capsule_generation/capsule_setup.py
@@ -4,10 +4,12 @@
 # --------------------------------------------------------------------
 
 
-__prog__        = "Sync and build edk2"
-__version__     = "1.0"
-__description__ = "Downloads the required files from github and builds" \
-                    "required executables for linux/windows.\n"
+__prog__ = "Sync and build edk2"
+__version__ = "1.0"
+__description__ = (
+    "Downloads the required files from github and builds"
+    "required executables for linux/windows.\n"
+)
 
 
 import requests
@@ -21,14 +23,18 @@ import validators
 import traceback
 
 
-edk2_branch="edk2-stable202008"
+edk2_branch = "edk2-stable202008"
 edk2_git_repo_sync_url = "https://github.com/tianocore/edk2.git"
 edk2_windows_base_tools_url = "https://github.com/tianocore/edk2-BaseTools-win32.git"
-generate_capsule_py_sync_url = "https://raw.githubusercontent.com/tianocore" \
-    "/edk2/ef91b07388e1c0a50c604e5350eeda98428ccea6/BaseTools/Source/Python" \
+generate_capsule_py_sync_url = (
+    "https://raw.githubusercontent.com/tianocore"
+    "/edk2/ef91b07388e1c0a50c604e5350eeda98428ccea6/BaseTools/Source/Python"
     "/Capsule/GenerateCapsule.py"
-basetools_common_sync_url = "https://github.com/tianocore/edk2/tree/" \
+)
+basetools_common_sync_url = (
+    "https://github.com/tianocore/edk2/tree/"
     "edk2-stable202008/BaseTools/Source/Python/Common"
+)
 
 
 ###
@@ -46,7 +52,7 @@ def run_make_command_linux(edk2_dir_path):
 
     try:
         os.chdir(edk2_dir_path)
-        subprocess.run(['make'], check=True)
+        subprocess.run(["make"], check=True)
     except:
         print("\n", traceback.format_exc())
         print("\nFailed to build edk2\n\n")
@@ -67,18 +73,22 @@ def update_edk2_submodules_linux(edk2_dir_path):
     os.chdir(edk2_dir_path)
 
     try:
-        subprocess.run( \
-            ['git', 'submodule', 'update', '--init', '--recursive'], \
-            check=True)
+        subprocess.run(
+            ["git", "submodule", "update", "--init", "--recursive"], check=True
+        )
     except:
-        print(f"\n\nFailed executing: subprocess.run(" \
-              "['git', 'submodule', 'update', '--init', '--recursive']," \
-            " check=True)\n\n")
+        print(
+            f"\n\nFailed executing: subprocess.run("
+            "['git', 'submodule', 'update', '--init', '--recursive'],"
+            " check=True)\n\n"
+        )
         print(traceback.format_exc())
 
-        return "Failed executing: subprocess.run(" \
-            "['git', 'submodule', 'update', '--init', '--recursive']," \
+        return (
+            "Failed executing: subprocess.run("
+            "['git', 'submodule', 'update', '--init', '--recursive'],"
             "check=True)"
+        )
 
     os.chdir(base_dir)
     print("initialization done")
@@ -88,12 +98,16 @@ def update_edk2_submodules_linux(edk2_dir_path):
 def print_header_sync_edk2_linux(clone_dir):
     print("\n\n\n")
     print("Copying edk2")
-    print("--------------------------------------------------------------" \
-          "------------------------------------")
+    print(
+        "--------------------------------------------------------------"
+        "------------------------------------"
+    )
     print(f"Github URL: {edk2_git_repo_sync_url}")
     print(f"Clone local path: {clone_dir}")
-    print("--------------------------------------------------------------" \
-          "------------------------------------")
+    print(
+        "--------------------------------------------------------------"
+        "------------------------------------"
+    )
     print("\n\n")
 
 
@@ -107,14 +121,13 @@ def sync_edk2_linux(edk2_git_repo_sync_url, edk2_dir_path):
 
     try:
         subprocess.run(
-            ['git', 'clone', edk2_git_repo_sync_url, edk2_dir_path],
-            check=True)
+            ["git", "clone", edk2_git_repo_sync_url, edk2_dir_path], check=True
+        )
         print(f"Repository cloned into {edk2_dir_path}")
 
     except subprocess.CalledProcessError as e:
         print(f"Error cloning repository: {e}")
         return "Error cloning repository"
-
 
     if update_edk2_submodules_linux(edk2_dir_path) != True:
         print("Failed to sync submodules")
@@ -125,9 +138,10 @@ def sync_edk2_linux(edk2_git_repo_sync_url, edk2_dir_path):
 
 def sync_and_build_edk2_linux(edk2_dir_path, c_dir):
 
-    if platform.system() == 'Linux':
-        edk2_get_repo_sync_stats = sync_edk2_linux(edk2_git_repo_sync_url,
-                                                   edk2_dir_path)
+    if platform.system() == "Linux":
+        edk2_get_repo_sync_stats = sync_edk2_linux(
+            edk2_git_repo_sync_url, edk2_dir_path
+        )
         if edk2_get_repo_sync_stats != True:
             return edk2_get_repo_sync_stats
 
@@ -147,13 +161,17 @@ def sync_and_build_edk2_linux(edk2_dir_path, c_dir):
 def print_header_sync_edk2_win(clone_dir, git_command):
     print("\n\n\n")
     print("Copying edk2")
-    print("--------------------------------------------------------------" \
-          "------------------------------------")
+    print(
+        "--------------------------------------------------------------"
+        "------------------------------------"
+    )
     print(f"Github URL: {edk2_windows_base_tools_url}")
     print(f"Clone local path: {clone_dir}")
     print(f"git clone command: {git_command}")
-    print("--------------------------------------------------------------" \
-          "------------------------------------")
+    print(
+        "--------------------------------------------------------------"
+        "------------------------------------"
+    )
     print("\n\n")
 
 
@@ -173,7 +191,7 @@ def sync_edk2_win(clone_dir):
         return f"Invalid URL: {edk2_git_repo_sync_url}"
 
     try:
-        subprocess.run('cmd /c ' + git_command, check=True)
+        subprocess.run("cmd /c " + git_command, check=True)
         print("\n\n\nEdk2 cloning complete\n\n")
     except:
         print("\n", traceback.format_exc())
@@ -186,10 +204,12 @@ def sync_edk2_win(clone_dir):
 def update_edk2_submodules_win(edk2_dir_path):
     try:
         os.chdir(edk2_dir_path)
-        subprocess.run(['git', 'submodule', 'update', '--init'], check=True)
+        subprocess.run(["git", "submodule", "update", "--init"], check=True)
     except:
-        print(f"Failed executing: subprocess.run(" \
-              "['git', 'submodule', 'update', '--init'], check=True)")
+        print(
+            f"Failed executing: subprocess.run("
+            "['git', 'submodule', 'update', '--init'], check=True)"
+        )
         print(traceback.format_exc())
         return False
     return True
@@ -199,10 +219,11 @@ def build_edk2(edk2_dir_path):
 
     try:
         os.chdir(edk2_dir_path)
-        subprocess.run(['edksetup.bat', 'Rebuild'], check=True)
+        subprocess.run(["edksetup.bat", "Rebuild"], check=True)
     except:
-        print(f"Failed executing: subprocess.run(" \
-              "['edksetup.bat', 'Rebuild'], check=True)")
+        print(
+            f"Failed executing: subprocess.run(['edksetup.bat', 'Rebuild'], check=True)"
+        )
         print(traceback.format_exc())
         return "Failed to build edk2"
     return True
@@ -231,7 +252,7 @@ def build_edk2_win(edk2_dir_path, full_build):
 
 def sync_and_build_edk2_win(clone_dir, full_build):
 
-    if platform.system() == 'Windows':
+    if platform.system() == "Windows":
         edk2_get_repo_sync_stats = sync_edk2_win(clone_dir)
         if edk2_get_repo_sync_stats != True:
             return edk2_get_repo_sync_stats
@@ -244,18 +265,16 @@ def sync_and_build_edk2_win(clone_dir, full_build):
 
 def force_delete_folder(folder_path):
 
-    if platform.system() == 'Windows':
+    if platform.system() == "Windows":
         try:
-            subprocess.run(
-                ['rmdir', '/S', '/Q', folder_path],
-                check=True, shell=True)
+            subprocess.run(["rmdir", "/S", "/Q", folder_path], check=True, shell=True)
             print(f"Folder deleted successfully: {folder_path}")
 
         except Exception as e:
             print(f"Failed to delete Dir {folder_path}")
             print(e)
 
-    if platform.system() == 'Linux':
+    if platform.system() == "Linux":
         try:
             shutil.rmtree(folder_path)
             print(f"Dir deleted successfully: {folder_path}")
@@ -278,17 +297,22 @@ def del_file(file_path):
 def print_header_sync_generate_capsule_py(generate_capsule_py_file_path_abs):
     print("\n\n\n")
     print("Copying GenerateCapsule.py")
-    print("--------------------------------------------------------------" \
-          "------------------------------------")
+    print(
+        "--------------------------------------------------------------"
+        "------------------------------------"
+    )
     print(f"Github URL: {generate_capsule_py_sync_url}")
     print(f"Clone local path: {generate_capsule_py_file_path_abs}")
-    print("--------------------------------------------------------------" \
-          "------------------------------------")
+    print(
+        "--------------------------------------------------------------"
+        "------------------------------------"
+    )
     print("\n\n")
 
 
-def sync_generate_capsule_py(generate_capsule_py_sync_url,
-                             generate_capsule_py_file_path_abs):
+def sync_generate_capsule_py(
+    generate_capsule_py_sync_url, generate_capsule_py_file_path_abs
+):
 
     if os.path.exists(generate_capsule_py_file_path_abs):
         print("\n\nGenerateCapsule.py  found\n\n")
@@ -304,12 +328,12 @@ def sync_generate_capsule_py(generate_capsule_py_sync_url,
     try:
         response = requests.get(generate_capsule_py_sync_url)
         if response.status_code == 200:
-            with open(generate_capsule_py_file_path_abs, 'wb') as file:
+            with open(generate_capsule_py_file_path_abs, "wb") as file:
                 file.write(response.content)
-            print('GenerateCapsule.py File downloaded successfully\n\n')
+            print("GenerateCapsule.py File downloaded successfully\n\n")
     except:
         print(traceback.format_exc())
-        print('\nFailed to download file\n\n')
+        print("\nFailed to download file\n\n")
         return "Failed to download file"
     return True
 
@@ -324,11 +348,11 @@ def copy_GenFv(base_dir_abs, genfv_path_win, genfv_local_path_abs):
         shutil.copy(genfv_path_win, base_dir_abs)
         print(f"Copied {genfv_path_win} to {base_dir_abs}")
     except:
-        print(f"\n\nFailed to copy GenFv.exe from {genfv_path_win} to " \
-              f"{base_dir_abs}\n\n")
+        print(
+            f"\n\nFailed to copy GenFv.exe from {genfv_path_win} to {base_dir_abs}\n\n"
+        )
         print(traceback.format_exc())
-        return f"Failed to copy GenFv.exe from {genfv_path_win} to " \
-            f"{base_dir_abs}"
+        return f"Failed to copy GenFv.exe from {genfv_path_win} to {base_dir_abs}"
 
     return True
 
@@ -343,30 +367,31 @@ def copy_GenFfs(base_dir_abs, genffs_path_win, genffs_local_path_abs):
         shutil.copy(genffs_path_win, base_dir_abs)
         print(f"Copied {genffs_path_win} to {base_dir_abs}")
     except:
-        print(f"\n\nFailed to copy GenFv.exe from {genffs_path_win} to " \
-              f"{base_dir_abs}\n\n")
+        print(
+            f"\n\nFailed to copy GenFv.exe from {genffs_path_win} to {base_dir_abs}\n\n"
+        )
         print(traceback.format_exc())
-        return f"Failed to copy GenFv.exe from {genffs_path_win} to " \
-                f"{base_dir_abs}"
+        return f"Failed to copy GenFv.exe from {genffs_path_win} to {base_dir_abs}"
 
     return True
 
 
-def print_header_sync_common_dir(branch,
-                                 common_dir,
-                                 local_path,
-                                 Common_dir_path):
+def print_header_sync_common_dir(branch, common_dir, local_path, Common_dir_path):
     print("\n\n\n")
     print("Copying common dir")
-    print("--------------------------------------------------------------" \
-          "------------------------------------")
+    print(
+        "--------------------------------------------------------------"
+        "------------------------------------"
+    )
     print(f"Github URL: {edk2_git_repo_sync_url}")
     print(f"Branch: {branch}")
     print(f"Clone local path: {Common_dir_path}")
     print(f"Local temp working path: {local_path}")
     print(f"Final copy path: {common_dir}")
-    print("--------------------------------------------------------------" \
-          "------------------------------------")
+    print(
+        "--------------------------------------------------------------"
+        "------------------------------------"
+    )
     print("\n\n")
 
 
@@ -376,25 +401,22 @@ def sync_single_dir(edk2_git_repo_sync_url, branch, target_dir, local_path):
         os.makedirs(local_path)
 
     try:
-        subprocess.run(['git', 'init'], cwd=local_path)
+        subprocess.run(["git", "init"], cwd=local_path)
         subprocess.run(
-            ['git', 'remote', 'add', 'origin', edk2_git_repo_sync_url],
-            cwd=local_path)
-        subprocess.run(
-            ['git', 'config','core.sparseCheckout', 'true'],
-            cwd=local_path)
+            ["git", "remote", "add", "origin", edk2_git_repo_sync_url], cwd=local_path
+        )
+        subprocess.run(["git", "config", "core.sparseCheckout", "true"], cwd=local_path)
 
-        sparse_checkout_file = os.path.join(local_path,
-                                            '.git',
-                                            'info',
-                                            'sparse-checkout')
+        sparse_checkout_file = os.path.join(
+            local_path, ".git", "info", "sparse-checkout"
+        )
         print(f"\n\nsparse_checkout_file: {sparse_checkout_file}\n\n")
-        if not os.path.exists(os.path.join(local_path, '.git', 'info')):
-            os.mkdir(os.path.join(local_path, '.git', 'info'))
-        with open(sparse_checkout_file, 'w') as f:
+        if not os.path.exists(os.path.join(local_path, ".git", "info")):
+            os.mkdir(os.path.join(local_path, ".git", "info"))
+        with open(sparse_checkout_file, "w") as f:
             f.write("%s/\n" % (target_dir))
 
-        subprocess.run(['git', 'pull', 'origin', branch], cwd=local_path)
+        subprocess.run(["git", "pull", "origin", branch], cwd=local_path)
     except:
         print(f"Failed to sync common dir")
         print(traceback.format_exc())
@@ -405,36 +427,36 @@ def sync_single_dir(edk2_git_repo_sync_url, branch, target_dir, local_path):
 
 def sync_common_dir(base_dir_abs, common_dir_local_sync_path_abs):
 
-    temp_local_working_dir_path = os.path.join(base_dir_abs,
-                                               "Common_sync")
-    Common_dir_path = os.path.join(temp_local_working_dir_path,
-                                   "BaseTools",
-                                   "Source",
-                                   "Python",
-                                   "Common")
+    temp_local_working_dir_path = os.path.join(base_dir_abs, "Common_sync")
+    Common_dir_path = os.path.join(
+        temp_local_working_dir_path, "BaseTools", "Source", "Python", "Common"
+    )
 
     if os.path.exists(common_dir_local_sync_path_abs):
         print("\n\nCommon dir found\n\n")
         return "Common dir found"
 
-    print_header_sync_common_dir(edk2_branch,
-                                 common_dir_local_sync_path_abs,
-                                 temp_local_working_dir_path,
-                                 Common_dir_path)
+    print_header_sync_common_dir(
+        edk2_branch,
+        common_dir_local_sync_path_abs,
+        temp_local_working_dir_path,
+        Common_dir_path,
+    )
 
     try:
-        sync_single_dir(edk2_git_repo_sync_url,
-                        edk2_branch,
-                        target_dir='BaseTools/Source/Python/Common',
-                        local_path=temp_local_working_dir_path)
+        sync_single_dir(
+            edk2_git_repo_sync_url,
+            edk2_branch,
+            target_dir="BaseTools/Source/Python/Common",
+            local_path=temp_local_working_dir_path,
+        )
         print("\n\nCompleted common folder sync\n\n")
     except:
         print("\n", traceback.format_exc())
         print("\nFailed to sync common dir from github\n\n")
         return "Failed to sync common dir from github"
 
-    shutil.copytree(Common_dir_path,
-                    common_dir_local_sync_path_abs)
+    shutil.copytree(Common_dir_path, common_dir_local_sync_path_abs)
 
     if os.path.exists(temp_local_working_dir_path):
         force_delete_folder(temp_local_working_dir_path)
@@ -442,12 +464,14 @@ def sync_common_dir(base_dir_abs, common_dir_local_sync_path_abs):
     return True
 
 
-def clean_build(clean_build,
-                generate_capsule_py_file_path_abs,
-                edk2_sync_local_path_abs,
-                genffs_path_abs,
-                genfv_path_abs,
-                common_dir_local_sync_path_abs):
+def clean_build(
+    clean_build,
+    generate_capsule_py_file_path_abs,
+    edk2_sync_local_path_abs,
+    genffs_path_abs,
+    genfv_path_abs,
+    common_dir_local_sync_path_abs,
+):
 
     if not clean_build:
         return True
@@ -481,28 +505,32 @@ def clean_build(clean_build,
     return True
 
 
-def print_stats(sync_generate_capsule_py_stats,
-                sync_and_build_edk2_win_stats,
-                copy_GenFfs_win_stats,
-                copy_GenFv_win_stats,
-                sync_common_dir_stats):
+def print_stats(
+    sync_generate_capsule_py_stats,
+    sync_and_build_edk2_win_stats,
+    copy_GenFfs_win_stats,
+    copy_GenFv_win_stats,
+    sync_common_dir_stats,
+):
 
     print("\n\n\n")
     print("Capsule setup status:")
-    print("--------------------------------------------------------------" \
-          "------------------------------------")
+    print(
+        "--------------------------------------------------------------"
+        "------------------------------------"
+    )
 
     if sync_generate_capsule_py_stats == True:
         print("Downloaded GenerateCapsule.py successfully")
     else:
-        print(f"Downloading GenerateCapsule.py failed: " \
-              f"{sync_generate_capsule_py_stats}")
+        print(
+            f"Downloading GenerateCapsule.py failed: {sync_generate_capsule_py_stats}"
+        )
 
     if sync_and_build_edk2_win_stats == True:
         print("Downloaded and Built EDK2 successfully")
     else:
-        print(f"Downloading and Building EDK2 failed: " \
-              f"{sync_and_build_edk2_win_stats}")
+        print(f"Downloading and Building EDK2 failed: {sync_and_build_edk2_win_stats}")
 
     if copy_GenFfs_win_stats == True:
         print("Copied GenFfs successfully")
@@ -518,134 +546,139 @@ def print_stats(sync_generate_capsule_py_stats,
         print("Downloaded Common directory successfully")
     else:
         print(f"Downloading Common directory failed: {sync_common_dir_stats}")
-    print("--------------------------------------------------------------" \
-          "------------------------------------")
+    print(
+        "--------------------------------------------------------------"
+        "------------------------------------"
+    )
     print("\n\n")
 
 
 def Main(args):
 
     if platform.system() == "Linux":
-
         base_dir_abs = os.path.dirname(os.path.abspath(__file__))
-        generate_capsule_py_file_path_abs = os.path.join(base_dir_abs,
-                                                         'GenerateCapsule.py')
-        edk2_sync_local_path_abs = os.path.join(base_dir_abs, 'edk2')
-        c_dir = os.path.join(edk2_sync_local_path_abs,
-                             'BaseTools',
-                             'Source',
-                             'C')
-        genffs_sync_path_linux_abs = os.path.join(c_dir, 'bin', 'GenFfs')
-        genfv_sync_path_linux_abs = os.path.join(c_dir, 'bin', 'GenFv')
-        genffs_local_path_abs = os.path.join(base_dir_abs, 'GenFfs')
-        genfv_local_path_abs = os.path.join(base_dir_abs, 'GenFv')
-        common_dir_local_sync_path_abs = os.path.join(base_dir_abs, 'Common')
+        generate_capsule_py_file_path_abs = os.path.join(
+            base_dir_abs, "GenerateCapsule.py"
+        )
+        edk2_sync_local_path_abs = os.path.join(base_dir_abs, "edk2")
+        c_dir = os.path.join(edk2_sync_local_path_abs, "BaseTools", "Source", "C")
+        genffs_sync_path_linux_abs = os.path.join(c_dir, "bin", "GenFfs")
+        genfv_sync_path_linux_abs = os.path.join(c_dir, "bin", "GenFv")
+        genffs_local_path_abs = os.path.join(base_dir_abs, "GenFfs")
+        genfv_local_path_abs = os.path.join(base_dir_abs, "GenFv")
+        common_dir_local_sync_path_abs = os.path.join(base_dir_abs, "Common")
 
-        clean_build(args.clean_build,
-                    generate_capsule_py_file_path_abs,
-                    edk2_sync_local_path_abs,
-                    genffs_local_path_abs,
-                    genfv_local_path_abs,
-                    common_dir_local_sync_path_abs)
+        clean_build(
+            args.clean_build,
+            generate_capsule_py_file_path_abs,
+            edk2_sync_local_path_abs,
+            genffs_local_path_abs,
+            genfv_local_path_abs,
+            common_dir_local_sync_path_abs,
+        )
 
         sync_generate_capsule_py_stats = sync_generate_capsule_py(
-                                            generate_capsule_py_sync_url,
-                                            generate_capsule_py_file_path_abs)
+            generate_capsule_py_sync_url, generate_capsule_py_file_path_abs
+        )
         sync_and_build_edk2_win_stats = sync_and_build_edk2_linux(
-                                            edk2_sync_local_path_abs,
-                                            c_dir)
-        copy_GenFfs_win_stats = copy_GenFfs(base_dir_abs,
-                                            genffs_sync_path_linux_abs,
-                                            genffs_local_path_abs)
-        copy_GenFv_win_stats = copy_GenFv(base_dir_abs,
-                                          genfv_sync_path_linux_abs,
-                                          genfv_local_path_abs)
+            edk2_sync_local_path_abs, c_dir
+        )
+        copy_GenFfs_win_stats = copy_GenFfs(
+            base_dir_abs, genffs_sync_path_linux_abs, genffs_local_path_abs
+        )
+        copy_GenFv_win_stats = copy_GenFv(
+            base_dir_abs, genfv_sync_path_linux_abs, genfv_local_path_abs
+        )
         sync_common_dir_stats = sync_common_dir(
-                                            base_dir_abs,
-                                            common_dir_local_sync_path_abs)
+            base_dir_abs, common_dir_local_sync_path_abs
+        )
 
-        print_stats(sync_generate_capsule_py_stats,
-                    sync_and_build_edk2_win_stats,
-                    copy_GenFfs_win_stats,
-                    copy_GenFv_win_stats,
-                    sync_common_dir_stats)
+        print_stats(
+            sync_generate_capsule_py_stats,
+            sync_and_build_edk2_win_stats,
+            copy_GenFfs_win_stats,
+            copy_GenFv_win_stats,
+            sync_common_dir_stats,
+        )
 
     if platform.system() == "Windows":
-
         base_dir_abs = os.path.dirname(os.path.abspath(__file__))
-        generate_capsule_py_file_path_abs = os.path.join(base_dir_abs,
-                                                         'GenerateCapsule.py')
-        edk2_sync_local_path_abs = os.path.join(base_dir_abs, 'edk2')
-        genffs_sync_path_win_abs = os.path.join(edk2_sync_local_path_abs,
-                                                'GenFfs.exe')
-        genfv_sync_path_win_abs = os.path.join(edk2_sync_local_path_abs,
-                                               'GenFv.exe')
-        genffs_local_path_abs = os.path.join(base_dir_abs, 'GenFfs.exe')
-        genfv_local_path_abs = os.path.join(base_dir_abs, 'GenFv.exe')
-        common_dir_local_sync_path_abs = os.path.join(base_dir_abs, 'Common')
+        generate_capsule_py_file_path_abs = os.path.join(
+            base_dir_abs, "GenerateCapsule.py"
+        )
+        edk2_sync_local_path_abs = os.path.join(base_dir_abs, "edk2")
+        genffs_sync_path_win_abs = os.path.join(edk2_sync_local_path_abs, "GenFfs.exe")
+        genfv_sync_path_win_abs = os.path.join(edk2_sync_local_path_abs, "GenFv.exe")
+        genffs_local_path_abs = os.path.join(base_dir_abs, "GenFfs.exe")
+        genfv_local_path_abs = os.path.join(base_dir_abs, "GenFv.exe")
+        common_dir_local_sync_path_abs = os.path.join(base_dir_abs, "Common")
 
-        clean_build(args.clean_build,
-                    generate_capsule_py_file_path_abs,
-                    edk2_sync_local_path_abs,
-                    genffs_local_path_abs,
-                    genfv_local_path_abs,
-                    common_dir_local_sync_path_abs)
+        clean_build(
+            args.clean_build,
+            generate_capsule_py_file_path_abs,
+            edk2_sync_local_path_abs,
+            genffs_local_path_abs,
+            genfv_local_path_abs,
+            common_dir_local_sync_path_abs,
+        )
 
         sync_generate_capsule_py_stats = sync_generate_capsule_py(
-                                            generate_capsule_py_sync_url,
-                                            generate_capsule_py_file_path_abs)
+            generate_capsule_py_sync_url, generate_capsule_py_file_path_abs
+        )
 
         sync_and_build_edk2_win_stats = sync_and_build_edk2_win(
-                                            edk2_sync_local_path_abs,
-                                            args.full_build)
+            edk2_sync_local_path_abs, args.full_build
+        )
 
         copy_GenFfs_win_stats = copy_GenFfs(
-                                    base_dir_abs,
-                                    genffs_sync_path_win_abs,
-                                    genffs_local_path_abs)
+            base_dir_abs, genffs_sync_path_win_abs, genffs_local_path_abs
+        )
 
         copy_GenFv_win_stats = copy_GenFv(
-                                    base_dir_abs,
-                                    genfv_sync_path_win_abs,
-                                    genfv_local_path_abs)
+            base_dir_abs, genfv_sync_path_win_abs, genfv_local_path_abs
+        )
 
         sync_common_dir_stats = sync_common_dir(
-                                    base_dir_abs,
-                                    common_dir_local_sync_path_abs)
+            base_dir_abs, common_dir_local_sync_path_abs
+        )
 
-        print_stats(sync_generate_capsule_py_stats,
-                    sync_and_build_edk2_win_stats,
-                    copy_GenFfs_win_stats,
-                    copy_GenFv_win_stats,
-                    sync_common_dir_stats)
+        print_stats(
+            sync_generate_capsule_py_stats,
+            sync_and_build_edk2_win_stats,
+            copy_GenFfs_win_stats,
+            copy_GenFv_win_stats,
+            sync_common_dir_stats,
+        )
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser (
-                            prog =
-                                __prog__,
-                            description =
-                                "VERSION: "
-                                +  __version__
-                                + ", "
-                                + __description__ ,
-                            conflict_handler =
-                                'resolve',
-                            )
+    parser = argparse.ArgumentParser(
+        prog=__prog__,
+        description="VERSION: " + __version__ + ", " + __description__,
+        conflict_handler="resolve",
+    )
 
-    parser.add_argument("-c", "--clean_build",
-                        dest = 'clean_build', default = False,
-                        help = "If set to 'True', " \
-                            "deletes any existing folders/files " \
-                            "and download again. Default - 'False'")
+    parser.add_argument(
+        "-c",
+        "--clean_build",
+        dest="clean_build",
+        default=False,
+        help="If set to 'True', "
+        "deletes any existing folders/files "
+        "and download again. Default - 'False'",
+    )
 
-    parser.add_argument("-f", "--full_build",
-                        dest = 'full_build', default = False,
-                        help = "If set to 'True', " \
-                            "downloads additional submodules " \
-                            "for a full edk2 build. " \
-                            "These submodules and full build are not " \
-                            "required for capsule update. Default - 'False'")
+    parser.add_argument(
+        "-f",
+        "--full_build",
+        dest="full_build",
+        default=False,
+        help="If set to 'True', "
+        "downloads additional submodules "
+        "for a full edk2 build. "
+        "These submodules and full build are not "
+        "required for capsule update. Default - 'False'",
+    )
 
     args = parser.parse_args()
     Main(args)

--- a/uefi_capsule_generation/capsule_setup.py
+++ b/uefi_capsule_generation/capsule_setup.py
@@ -12,15 +12,15 @@ __description__ = (
 )
 
 
-import requests
-import subprocess
-import os
-import shutil
-import platform
 import argparse
-import validators
+import os
+import platform
+import shutil
+import subprocess
 import traceback
 
+import requests
+import validators
 
 edk2_branch = "edk2-stable202008"
 edk2_git_repo_sync_url = "https://github.com/tianocore/edk2.git"

--- a/uefi_capsule_generation/capsule_setup.py
+++ b/uefi_capsule_generation/capsule_setup.py
@@ -52,7 +52,7 @@ def run_make_command_linux(edk2_dir_path):
     try:
         os.chdir(edk2_dir_path)
         subprocess.run(["make"], check=True)
-    except:
+    except Exception:
         print("\n", traceback.format_exc())
         print("\nFailed to build edk2\n\n")
         return "Failed to build edk2"
@@ -75,7 +75,7 @@ def update_edk2_submodules_linux(edk2_dir_path):
         subprocess.run(
             ["git", "submodule", "update", "--init", "--recursive"], check=True
         )
-    except:
+    except Exception:
         print(
             "\n\nFailed executing: subprocess.run("
             "['git', 'submodule', 'update', '--init', '--recursive'],"
@@ -192,7 +192,7 @@ def sync_edk2_win(clone_dir):
     try:
         subprocess.run("cmd /c " + git_command, check=True)
         print("\n\n\nEdk2 cloning complete\n\n")
-    except:
+    except Exception:
         print("\n", traceback.format_exc())
         print("\nFailed to sync edk2 from github\n\n")
         return "Failed to sync edk2 from github"
@@ -204,7 +204,7 @@ def update_edk2_submodules_win(edk2_dir_path):
     try:
         os.chdir(edk2_dir_path)
         subprocess.run(["git", "submodule", "update", "--init"], check=True)
-    except:
+    except Exception:
         print(
             "Failed executing: subprocess.run("
             "['git', 'submodule', 'update', '--init'], check=True)"
@@ -219,7 +219,7 @@ def build_edk2(edk2_dir_path):
     try:
         os.chdir(edk2_dir_path)
         subprocess.run(["edksetup.bat", "Rebuild"], check=True)
-    except:
+    except Exception:
         print(
             "Failed executing: subprocess.run(['edksetup.bat', 'Rebuild'], check=True)"
         )
@@ -288,7 +288,7 @@ def del_file(file_path):
         os.remove(file_path)
         print(f"File deleted successfully: {file_path}")
 
-    except:
+    except Exception:
         print(f"Failed to delete file: {file_path}")
         print(traceback.format_exc())
 
@@ -330,7 +330,7 @@ def sync_generate_capsule_py(
             with open(generate_capsule_py_file_path_abs, "wb") as file:
                 file.write(response.content)
             print("GenerateCapsule.py File downloaded successfully\n\n")
-    except:
+    except Exception:
         print(traceback.format_exc())
         print("\nFailed to download file\n\n")
         return "Failed to download file"
@@ -346,7 +346,7 @@ def copy_GenFv(base_dir_abs, genfv_path_win, genfv_local_path_abs):
     try:
         shutil.copy(genfv_path_win, base_dir_abs)
         print(f"Copied {genfv_path_win} to {base_dir_abs}")
-    except:
+    except Exception:
         print(
             f"\n\nFailed to copy GenFv.exe from {genfv_path_win} to {base_dir_abs}\n\n"
         )
@@ -365,7 +365,7 @@ def copy_GenFfs(base_dir_abs, genffs_path_win, genffs_local_path_abs):
     try:
         shutil.copy(genffs_path_win, base_dir_abs)
         print(f"Copied {genffs_path_win} to {base_dir_abs}")
-    except:
+    except Exception:
         print(
             f"\n\nFailed to copy GenFv.exe from {genffs_path_win} to {base_dir_abs}\n\n"
         )
@@ -416,7 +416,7 @@ def sync_single_dir(edk2_git_repo_sync_url, branch, target_dir, local_path):
             f.write("%s/\n" % (target_dir))
 
         subprocess.run(["git", "pull", "origin", branch], cwd=local_path)
-    except:
+    except Exception:
         print("Failed to sync common dir")
         print(traceback.format_exc())
         return "Failed to sync common dir"
@@ -450,7 +450,7 @@ def sync_common_dir(base_dir_abs, common_dir_local_sync_path_abs):
             local_path=temp_local_working_dir_path,
         )
         print("\n\nCompleted common folder sync\n\n")
-    except:
+    except Exception:
         print("\n", traceback.format_exc())
         print("\nFailed to sync common dir from github\n\n")
         return "Failed to sync common dir from github"

--- a/uefi_capsule_generation/capsule_setup.py
+++ b/uefi_capsule_generation/capsule_setup.py
@@ -17,7 +17,6 @@ import subprocess
 import os
 import shutil
 import platform
-import stat
 import argparse
 import validators
 import traceback
@@ -78,7 +77,7 @@ def update_edk2_submodules_linux(edk2_dir_path):
         )
     except:
         print(
-            f"\n\nFailed executing: subprocess.run("
+            "\n\nFailed executing: subprocess.run("
             "['git', 'submodule', 'update', '--init', '--recursive'],"
             " check=True)\n\n"
         )
@@ -187,7 +186,7 @@ def sync_edk2_win(clone_dir):
 
     if not validators.url(edk2_git_repo_sync_url):
         print(f"Invalid URL: {edk2_git_repo_sync_url}")
-        print(f"Terminated copying edk2")
+        print("Terminated copying edk2")
         return f"Invalid URL: {edk2_git_repo_sync_url}"
 
     try:
@@ -207,7 +206,7 @@ def update_edk2_submodules_win(edk2_dir_path):
         subprocess.run(["git", "submodule", "update", "--init"], check=True)
     except:
         print(
-            f"Failed executing: subprocess.run("
+            "Failed executing: subprocess.run("
             "['git', 'submodule', 'update', '--init'], check=True)"
         )
         print(traceback.format_exc())
@@ -222,7 +221,7 @@ def build_edk2(edk2_dir_path):
         subprocess.run(["edksetup.bat", "Rebuild"], check=True)
     except:
         print(
-            f"Failed executing: subprocess.run(['edksetup.bat', 'Rebuild'], check=True)"
+            "Failed executing: subprocess.run(['edksetup.bat', 'Rebuild'], check=True)"
         )
         print(traceback.format_exc())
         return "Failed to build edk2"
@@ -322,7 +321,7 @@ def sync_generate_capsule_py(
 
     if not validators.url(generate_capsule_py_sync_url):
         print(f"Invalid URL: {generate_capsule_py_sync_url}")
-        print(f"Terminated copying GenerateCapsule.py")
+        print("Terminated copying GenerateCapsule.py")
         return f"Invalid URL: {generate_capsule_py_sync_url}"
 
     try:
@@ -418,7 +417,7 @@ def sync_single_dir(edk2_git_repo_sync_url, branch, target_dir, local_path):
 
         subprocess.run(["git", "pull", "origin", branch], cwd=local_path)
     except:
-        print(f"Failed to sync common dir")
+        print("Failed to sync common dir")
         print(traceback.format_exc())
         return "Failed to sync common dir"
 

--- a/uefi_capsule_generation/create_config_json.py
+++ b/uefi_capsule_generation/create_config_json.py
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 # --------------------------------------------------------------------
 
-import traceback
 import json
-import os
 from collections import OrderedDict
 
 

--- a/uefi_capsule_generation/create_config_json.py
+++ b/uefi_capsule_generation/create_config_json.py
@@ -8,6 +8,7 @@ import json
 import os
 from collections import OrderedDict
 
+
 def create_config():
 
     config_json_data = OrderedDict()
@@ -25,7 +26,7 @@ def create_config():
     Payloads_entry_dict["OpenSslTrustedPublicCertFile"] = ""
     Payloads_entry_dict["SigningToolPath"] = ""
 
-    config_json_data['Payloads'] = [Payloads_entry_dict]
+    config_json_data["Payloads"] = [Payloads_entry_dict]
 
-    with open('config.json', 'w') as json_file:
+    with open("config.json", "w") as json_file:
         json.dump(config_json_data, json_file, indent=4)

--- a/uefi_capsule_generation/set_dtb_property.py
+++ b/uefi_capsule_generation/set_dtb_property.py
@@ -2,10 +2,11 @@
 # Copyright (c) Qualcomm Innovation Center, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause-Clear
 
-import libfdt
 import re
 import struct
 import sys
+
+import libfdt
 
 
 def encode_value(value: str) -> bytes:

--- a/uefi_capsule_generation/set_dtb_property.py
+++ b/uefi_capsule_generation/set_dtb_property.py
@@ -7,7 +7,6 @@ import re
 import struct
 import sys
 
-from pathlib import Path
 
 
 def encode_value(value: str) -> bytes:

--- a/uefi_capsule_generation/set_dtb_property.py
+++ b/uefi_capsule_generation/set_dtb_property.py
@@ -9,6 +9,7 @@ import sys
 
 from pathlib import Path
 
+
 def encode_value(value: str) -> bytes:
     """
     Encode a value for FDT:
@@ -26,9 +27,11 @@ def encode_value(value: str) -> bytes:
         with open(file_path, "rb") as f:
             data = f.read()
         if len(data) % 4 != 0:
-            data += b'\x00' * (4 - (len(data) % 4))
-        return b''.join(struct.pack(">I", struct.unpack(">I", data[i:i+4])[0])
-                        for i in range(0, len(data), 4))
+            data += b"\x00" * (4 - (len(data) % 4))
+        return b"".join(
+            struct.pack(">I", struct.unpack(">I", data[i : i + 4])[0])
+            for i in range(0, len(data), 4)
+        )
 
     # Integer list from file
     if value.startswith("@list:"):
@@ -36,24 +39,33 @@ def encode_value(value: str) -> bytes:
         with open(file_path, "r") as f:
             text = f.read()
         # Split on whitespace or commas
-        parts = re.split(r'[\s,]+', text.strip())
-        return b''.join(struct.pack(">I", int(p, 16)) for p in parts if p)
+        parts = re.split(r"[\s,]+", text.strip())
+        return b"".join(struct.pack(">I", int(p, 16)) for p in parts if p)
 
     # Single integer
-    int_pattern = re.compile(r'^-?(0x[0-9a-fA-F]+|\d+)$')
-    int_list_pattern = re.compile(r'^(-?(0x[0-9a-fA-F]+|\d+)[ ,]+)+(-?(0x[0-9a-fA-F]+|\d+))$')
+    int_pattern = re.compile(r"^-?(0x[0-9a-fA-F]+|\d+)$")
+    int_list_pattern = re.compile(
+        r"^(-?(0x[0-9a-fA-F]+|\d+)[ ,]+)+(-?(0x[0-9a-fA-F]+|\d+))$"
+    )
 
     if int_pattern.match(value):
-        return struct.pack('>I', int(value, 0))
+        return struct.pack(">I", int(value, 0))
     elif int_list_pattern.match(value + " "):
-        parts = re.split(r'[ ,]+', value.strip())
-        return b''.join(struct.pack('>I', int(p, 0)) for p in parts if p)
+        parts = re.split(r"[ ,]+", value.strip())
+        return b"".join(struct.pack(">I", int(p, 0)) for p in parts if p)
     else:
         # Default: UTF-8 string
-        return value.encode('utf-8')
+        return value.encode("utf-8")
 
-def set_dtb_property(dtb_path: str, node_path: str, prop_name: str, value: str,
-                     out_path: str, extra_space: int = 1024):
+
+def set_dtb_property(
+    dtb_path: str,
+    node_path: str,
+    prop_name: str,
+    value: str,
+    out_path: str,
+    extra_space: int = 1024,
+):
     """
     Set or add a property in a DTB, automatically resizing if needed.
     """
@@ -77,7 +89,9 @@ def set_dtb_property(dtb_path: str, node_path: str, prop_name: str, value: str,
         if hasattr(e, "err") and e.err == -libfdt.FDT_ERR_NOSPACE:
             print("[!] Not enough space, resizing DTB...")
             # Resize DTB buffer to fit new property
-            fdt_obj.resize(len(fdt_obj.as_bytearray()) + max(len(value_bytes), extra_space))
+            fdt_obj.resize(
+                len(fdt_obj.as_bytearray()) + max(len(value_bytes), extra_space)
+            )
             # Retry setting the property
             fdt_obj.setprop(node_off, prop_name, value_bytes)
         else:
@@ -89,9 +103,12 @@ def set_dtb_property(dtb_path: str, node_path: str, prop_name: str, value: str,
 
     print(f"[+] Updated '{prop_name}' at '{node_path}', written to {out_path}")
 
+
 if __name__ == "__main__":
     if len(sys.argv) != 6:
-        print(f"Usage: {sys.argv[0]} <input.dtb> <node_path> <property> <value|@file:path|@list:path> <output.dtb>")
+        print(
+            f"Usage: {sys.argv[0]} <input.dtb> <node_path> <property> <value|@file:path|@list:path> <output.dtb>"
+        )
         sys.exit(1)
 
     input_dtb, node_path, prop_name, value, output_dtb = sys.argv[1:]

--- a/uefi_capsule_generation/set_dtb_property.py
+++ b/uefi_capsule_generation/set_dtb_property.py
@@ -8,7 +8,6 @@ import struct
 import sys
 
 
-
 def encode_value(value: str) -> bytes:
     """
     Encode a value for FDT:

--- a/uefi_capsule_generation/xblconfig_parser.py
+++ b/uefi_capsule_generation/xblconfig_parser.py
@@ -7,9 +7,9 @@ import hashlib
 import io
 import os
 import struct
-
 from dataclasses import dataclass
 from typing import List, Tuple
+
 from elftools.elf.elffile import ELFFile
 
 # =========================================================

--- a/uefi_capsule_generation/xblconfig_parser.py
+++ b/uefi_capsule_generation/xblconfig_parser.py
@@ -17,9 +17,11 @@ from elftools.elf.elffile import ELFFile
 # Helpers
 # =========================================================
 
+
 def align_up(x: int, a: int) -> int:
     r = x % a
     return x if r == 0 else x + (a - r)
+
 
 # =========================================================
 # Metadata v2 parsing (Program Header blob)
@@ -38,6 +40,7 @@ def align_up(x: int, a: int) -> int:
 #   PAD so THIS ITEM'S TOTAL SIZE is a multiple of 8
 # =========================================================
 
+
 @dataclass
 class MetaHeader:
     xcfg_type: str
@@ -45,6 +48,7 @@ class MetaHeader:
     minor: int
     entries: int
     meta_size: int
+
 
 @dataclass
 class MetaItemV2:
@@ -55,20 +59,24 @@ class MetaItemV2:
     platforminfo: int
     config_name_len: int
     config_name: str
-    start_off: int   # byte offset of this item's start inside the meta blob
-    end_off: int     # byte offset just past this item (after padding)
+    start_off: int  # byte offset of this item's start inside the meta blob
+    end_off: int  # byte offset just past this item (after padding)
+
 
 def parse_meta_header(blob: bytes, off: int = 0) -> Tuple[MetaHeader, int]:
     if off + 12 > len(blob):
         raise ValueError("Metadata header truncated")
-    xcfg_type = blob[off:off+4].decode("ascii", errors="replace")
-    major = blob[off+4]
-    minor = blob[off+5]
-    entries = int.from_bytes(blob[off+6:off+8], "little")
-    meta_size = int.from_bytes(blob[off+8:off+12], "little")
+    xcfg_type = blob[off : off + 4].decode("ascii", errors="replace")
+    major = blob[off + 4]
+    minor = blob[off + 5]
+    entries = int.from_bytes(blob[off + 6 : off + 8], "little")
+    meta_size = int.from_bytes(blob[off + 8 : off + 12], "little")
     return MetaHeader(xcfg_type, major, minor, entries, meta_size), off + 12
 
-def parse_meta_items_v2(blob: bytes, off: int, count: int) -> Tuple[List[MetaItemV2], int]:
+
+def parse_meta_items_v2(
+    blob: bytes, off: int, count: int
+) -> Tuple[List[MetaItemV2], int]:
     items: List[MetaItemV2] = []
     cur = off
     for idx in range(count):
@@ -77,12 +85,12 @@ def parse_meta_items_v2(blob: bytes, off: int, count: int) -> Tuple[List[MetaIte
         # fixed 32 bytes
         if cur + 32 > len(blob):
             raise ValueError(f"Metadata v2 item {idx} truncated (fixed part)")
-        attributes          = int.from_bytes(blob[cur+0:cur+4],   "little")
-        ofs_from_meta_start = int.from_bytes(blob[cur+4:cur+8],   "little")
-        item_size           = int.from_bytes(blob[cur+8:cur+12],  "little")
-        chipinfo            = int.from_bytes(blob[cur+12:cur+20], "little")
-        platforminfo        = int.from_bytes(blob[cur+20:cur+28], "little")
-        name_len            = int.from_bytes(blob[cur+28:cur+32], "little")
+        attributes = int.from_bytes(blob[cur + 0 : cur + 4], "little")
+        ofs_from_meta_start = int.from_bytes(blob[cur + 4 : cur + 8], "little")
+        item_size = int.from_bytes(blob[cur + 8 : cur + 12], "little")
+        chipinfo = int.from_bytes(blob[cur + 12 : cur + 20], "little")
+        platforminfo = int.from_bytes(blob[cur + 20 : cur + 28], "little")
+        name_len = int.from_bytes(blob[cur + 28 : cur + 32], "little")
         cur += 32
 
         # variable-length name
@@ -90,42 +98,49 @@ def parse_meta_items_v2(blob: bytes, off: int, count: int) -> Tuple[List[MetaIte
             raise ValueError(
                 f"Metadata v2 item {idx} name truncated (need {name_len} at 0x{cur:x}, buf=0x{len(blob):x})"
             )
-        config_name = blob[cur:cur+name_len].decode("utf-8", errors="replace")
+        config_name = blob[cur : cur + name_len].decode("utf-8", errors="replace")
         cur += name_len
 
         # pad so THIS item's total size is a multiple of 8
         item_len_now = cur - item_start
-        padded_len   = align_up(item_len_now, 8)
+        padded_len = align_up(item_len_now, 8)
         cur = item_start + padded_len
 
-        items.append(MetaItemV2(
-            attributes=attributes,
-            offset_from_meta_start=ofs_from_meta_start,
-            item_size=item_size,
-            chipinfo=chipinfo,
-            platforminfo=platforminfo,
-            config_name_len=name_len,
-            config_name=config_name,
-            start_off=item_start,
-            end_off=cur
-        ))
+        items.append(
+            MetaItemV2(
+                attributes=attributes,
+                offset_from_meta_start=ofs_from_meta_start,
+                item_size=item_size,
+                chipinfo=chipinfo,
+                platforminfo=platforminfo,
+                config_name_len=name_len,
+                config_name=config_name,
+                start_off=item_start,
+                end_off=cur,
+            )
+        )
     return items, cur
+
 
 # =========================================================
 # ELF helpers
 # =========================================================
+
 
 def load_elf(elf_path: str) -> Tuple[bytearray, ELFFile, List]:
     """Read the ELF once, and create an ELFFile bound to an in-memory stream."""
     with open(elf_path, "rb") as f:
         file_bytes = f.read()
     data = bytearray(file_bytes)
-    elf_stream = io.BytesIO(file_bytes)   # prevents 'seek of closed file'
+    elf_stream = io.BytesIO(file_bytes)  # prevents 'seek of closed file'
     elf = ELFFile(elf_stream)
     segments = list(elf.iter_segments())
     return data, elf, segments
 
-def parse_metadata_from_ph(elf: ELFFile, meta_ph_index: int) -> Tuple[MetaHeader, List[MetaItemV2], bytes, int]:
+
+def parse_metadata_from_ph(
+    elf: ELFFile, meta_ph_index: int
+) -> Tuple[MetaHeader, List[MetaItemV2], bytes, int]:
     """Return (header, items, meta_blob, meta_file_offset)."""
     segments = list(elf.iter_segments())
     if not segments or meta_ph_index >= len(segments):
@@ -135,15 +150,17 @@ def parse_metadata_from_ph(elf: ELFFile, meta_ph_index: int) -> Tuple[MetaHeader
     meta_blob = meta_seg.data()
     # file offset of the metadata segment (needed for absolute writes if ever used)
     ph = elf._get_segment_header(meta_ph_index)
-    meta_file_off = ph['p_offset']
+    meta_file_off = ph["p_offset"]
 
     hdr, off = parse_meta_header(meta_blob, 0)
     items, _ = parse_meta_items_v2(meta_blob, off, hdr.entries)
     return hdr, items, meta_blob, meta_file_off
 
+
 # =========================================================
 # Helpers for patching ELF program / section headers
 # =========================================================
+
 
 def _ph_file_offset_field(is_64: bool) -> Tuple[int, int]:
     """Return (field_offset_in_phdr, field_size) for p_offset."""
@@ -153,6 +170,7 @@ def _ph_file_offset_field(is_64: bool) -> Tuple[int, int]:
         return 8, 8
     return 4, 4
 
+
 def _ph_filesz_field(is_64: bool) -> Tuple[int, int]:
     """Return (field_offset_in_phdr, field_size) for p_filesz."""
     # ELF32 Phdr layout: type(4) offset(4) vaddr(4) paddr(4) filesz(4) memsz(4) flags(4) align(4)
@@ -161,10 +179,12 @@ def _ph_filesz_field(is_64: bool) -> Tuple[int, int]:
         return 0x20, 8
     return 0x10, 4
 
+
 def _ph_memsz_field(is_64: bool) -> Tuple[int, int]:
     if is_64:
         return 0x28, 8
     return 0x14, 4
+
 
 def _sh_offset_field(is_64: bool) -> Tuple[int, int]:
     """Return (field_offset_in_shdr, field_size) for sh_offset."""
@@ -174,29 +194,46 @@ def _sh_offset_field(is_64: bool) -> Tuple[int, int]:
         return 24, 8
     return 16, 4
 
+
 def _pack(endian: str, size: int, value: int) -> bytes:
     fmt = endian + {4: "I", 8: "Q"}[size]
     return struct.pack(fmt, value)
 
-def _write_ph_field(data: bytearray, elf: ELFFile, seg_idx: int,
-                    field_off: int, field_size: int, value: int) -> None:
-    endian = "<" if elf.little_endian else ">"
-    phoff   = elf.header['e_phoff']
-    phentsz = elf.header['e_phentsize']
-    pos = phoff + seg_idx * phentsz + field_off
-    data[pos:pos+field_size] = _pack(endian, field_size, value)
 
-def _write_sh_field(data: bytearray, elf: ELFFile, sec_idx: int,
-                    field_off: int, field_size: int, value: int) -> None:
-    endian  = "<" if elf.little_endian else ">"
-    shoff   = elf.header['e_shoff']
-    shentsz = elf.header['e_shentsize']
+def _write_ph_field(
+    data: bytearray,
+    elf: ELFFile,
+    seg_idx: int,
+    field_off: int,
+    field_size: int,
+    value: int,
+) -> None:
+    endian = "<" if elf.little_endian else ">"
+    phoff = elf.header["e_phoff"]
+    phentsz = elf.header["e_phentsize"]
+    pos = phoff + seg_idx * phentsz + field_off
+    data[pos : pos + field_size] = _pack(endian, field_size, value)
+
+
+def _write_sh_field(
+    data: bytearray,
+    elf: ELFFile,
+    sec_idx: int,
+    field_off: int,
+    field_size: int,
+    value: int,
+) -> None:
+    endian = "<" if elf.little_endian else ">"
+    shoff = elf.header["e_shoff"]
+    shentsz = elf.header["e_shentsize"]
     pos = shoff + sec_idx * shentsz + field_off
-    data[pos:pos+field_size] = _pack(endian, field_size, value)
+    data[pos : pos + field_size] = _pack(endian, field_size, value)
+
 
 # =========================================================
 # Dump logic based on metadata -> PH index (i + 2)
 # =========================================================
+
 
 def safe_filename(path: str) -> str:
     """Sanitize filename minimally: drop path components and disallow empty names."""
@@ -204,6 +241,7 @@ def safe_filename(path: str) -> str:
     if not name:
         name = "unnamed"
     return name
+
 
 def dump_from_meta(elf_path: str, out_dir: str, meta_ph_index: int) -> None:
     data, elf, segments = load_elf(elf_path)
@@ -213,8 +251,10 @@ def dump_from_meta(elf_path: str, out_dir: str, meta_ph_index: int) -> None:
 
     os.makedirs(out_dir, exist_ok=True)
 
-    print(f"Metadata (PH#{meta_ph_index}) xcfg_type='{hdr.xcfg_type}' "
-          f"v{hdr.major}.{hdr.minor} entries={hdr.entries} meta_size={hdr.meta_size}")
+    print(
+        f"Metadata (PH#{meta_ph_index}) xcfg_type='{hdr.xcfg_type}' "
+        f"v{hdr.major}.{hdr.minor} entries={hdr.entries} meta_size={hdr.meta_size}"
+    )
     print(f"Dumping items -> program headers starting at index 2 (i -> PH i+2):\n")
 
     for idx, it in enumerate(items):
@@ -222,8 +262,10 @@ def dump_from_meta(elf_path: str, out_dir: str, meta_ph_index: int) -> None:
 
         ph_index = idx + 2
         if ph_index >= len(segments):
-            print(f"  [i] WARN config_item[{idx}] name='{name}': "
-                  f"PH#{ph_index} doesn't exist (ELF has {len(segments)} segments)")
+            print(
+                f"  [i] WARN config_item[{idx}] name='{name}': "
+                f"PH#{ph_index} doesn't exist (ELF has {len(segments)} segments)"
+            )
             continue
 
         seg = segments[ph_index]
@@ -231,8 +273,10 @@ def dump_from_meta(elf_path: str, out_dir: str, meta_ph_index: int) -> None:
         to_write = min(len(seg_bytes), it.item_size)
 
         if to_write < it.item_size:
-            print(f"  [i] WARN config_item[{idx}] name='{name}': "
-                  f"item_size={it.item_size} > segment_size={len(seg_bytes)}; clipping to {to_write}")
+            print(
+                f"  [i] WARN config_item[{idx}] name='{name}': "
+                f"item_size={it.item_size} > segment_size={len(seg_bytes)}; clipping to {to_write}"
+            )
 
         out_name = safe_filename(name)
         # If duplicate names appear, suffix with index to avoid overwrite
@@ -244,17 +288,26 @@ def dump_from_meta(elf_path: str, out_dir: str, meta_ph_index: int) -> None:
         with open(out_path, "wb") as out:
             out.write(seg_bytes[:to_write])
 
-        print(f"  [+] config_item[{idx}] -> PH#{ph_index:>2} -> '{out_path}' ({to_write} bytes)")
+        print(
+            f"  [+] config_item[{idx}] -> PH#{ph_index:>2} -> '{out_path}' ({to_write} bytes)"
+        )
 
     print("\nDone.")
+
 
 # =========================================================
 # Replace logic: swap payload in a given program header,
 # update metadata item_size, and update the SHA-384 hash.
 # =========================================================
 
-def replace_ph(elf_path: str, target_ph_index: int, new_file: str,
-               output_file: str, meta_ph_index: int) -> None:
+
+def replace_ph(
+    elf_path: str,
+    target_ph_index: int,
+    new_file: str,
+    output_file: str,
+    meta_ph_index: int,
+) -> None:
     """Replace the payload in program header *target_ph_index* with the
     contents of *new_file*, then patch:
       - ELF program-header p_filesz / p_memsz
@@ -265,16 +318,18 @@ def replace_ph(elf_path: str, target_ph_index: int, new_file: str,
     data, elf, segments = load_elf(elf_path)
 
     if target_ph_index >= len(segments):
-        raise IndexError(f"Target program header #{target_ph_index} not found "
-                         f"(ELF has {len(segments)} segments)")
+        raise IndexError(
+            f"Target program header #{target_ph_index} not found "
+            f"(ELF has {len(segments)} segments)"
+        )
 
     # ----------------------------------------------------------
     # Load payloads
     # ----------------------------------------------------------
-    old_seg    = segments[target_ph_index]
-    old_data   = old_seg.data()
-    old_size   = old_seg['p_filesz']
-    seg_offset = old_seg['p_offset']
+    old_seg = segments[target_ph_index]
+    old_data = old_seg.data()
+    old_size = old_seg["p_filesz"]
+    seg_offset = old_seg["p_offset"]
 
     with open(new_file, "rb") as f:
         new_data = f.read()
@@ -283,15 +338,17 @@ def replace_ph(elf_path: str, target_ph_index: int, new_file: str,
     old_hash = hashlib.sha384(old_data[:old_size]).digest()
     new_hash = hashlib.sha384(new_data).digest()
 
-    print(f"[i] Replacing PH#{target_ph_index}: old size={old_size}, new size={new_size}")
+    print(
+        f"[i] Replacing PH#{target_ph_index}: old size={old_size}, new size={new_size}"
+    )
     print(f"[i] Old SHA-384: {old_hash.hex()}")
     print(f"[i] New SHA-384: {new_hash.hex()}")
 
-    is_64   = elf.elfclass == 64
-    endian  = "<" if elf.little_endian else ">"
-    phoff   = elf.header['e_phoff']
-    phentsz = elf.header['e_phentsize']
-    shoff   = elf.header['e_shoff']
+    is_64 = elf.elfclass == 64
+    endian = "<" if elf.little_endian else ">"
+    phoff = elf.header["e_phoff"]
+    phentsz = elf.header["e_phentsize"]
+    shoff = elf.header["e_shoff"]
 
     grow_size = new_size - old_size
 
@@ -300,40 +357,40 @@ def replace_ph(elf_path: str, target_ph_index: int, new_file: str,
     # ----------------------------------------------------------
     if grow_size <= 0:
         # In-place replacement (shrink or same size)
-        data[seg_offset:seg_offset + new_size] = new_data
+        data[seg_offset : seg_offset + new_size] = new_data
         if grow_size < 0:
             # Zero-fill the freed tail so stale bytes don't confuse readers
-            data[seg_offset + new_size:seg_offset + old_size] = b"\x00" * (-grow_size)
+            data[seg_offset + new_size : seg_offset + old_size] = b"\x00" * (-grow_size)
     else:
         # Segment grows: splice bytes and fix up all later offsets
-        tail = bytes(data[seg_offset + old_size:])
-        data[seg_offset:seg_offset + new_size] = new_data
+        tail = bytes(data[seg_offset + old_size :])
+        data[seg_offset : seg_offset + new_size] = new_data
         new_tail_start = seg_offset + new_size
-        data[new_tail_start:new_tail_start + len(tail)] = tail
+        data[new_tail_start : new_tail_start + len(tail)] = tail
         data.extend(b"\x00" * grow_size)
 
         off_field, off_field_sz = _ph_file_offset_field(is_64)
 
         # Shift p_offset for every program header whose content lies after ours
         for i, seg in enumerate(segments):
-            if seg['p_offset'] > seg_offset:
-                new_off = seg['p_offset'] + grow_size
+            if seg["p_offset"] > seg_offset:
+                new_off = seg["p_offset"] + grow_size
                 _write_ph_field(data, elf, i, off_field, off_field_sz, new_off)
 
         # Shift sh_offset for every section header whose content lies after ours
         sh_off_field, sh_off_field_sz = _sh_offset_field(is_64)
         for i, sec in enumerate(elf.iter_sections()):
-            if sec['sh_offset'] > seg_offset:
-                new_off = sec['sh_offset'] + grow_size
+            if sec["sh_offset"] > seg_offset:
+                new_off = sec["sh_offset"] + grow_size
                 _write_sh_field(data, elf, i, sh_off_field, sh_off_field_sz, new_off)
 
     # ----------------------------------------------------------
     # Update p_filesz and p_memsz of the target program header
     # ----------------------------------------------------------
     filesz_field, filesz_field_sz = _ph_filesz_field(is_64)
-    memsz_field,  memsz_field_sz  = _ph_memsz_field(is_64)
+    memsz_field, memsz_field_sz = _ph_memsz_field(is_64)
     _write_ph_field(data, elf, target_ph_index, filesz_field, filesz_field_sz, new_size)
-    _write_ph_field(data, elf, target_ph_index, memsz_field,  memsz_field_sz,  new_size)
+    _write_ph_field(data, elf, target_ph_index, memsz_field, memsz_field_sz, new_size)
 
     # ----------------------------------------------------------
     # Update item_size in the metadata blob
@@ -345,32 +402,42 @@ def replace_ph(elf_path: str, target_ph_index: int, new_file: str,
     meta_item_index = target_ph_index - 2
     if meta_item_index >= 0:
         try:
-            _, items, meta_blob, meta_file_off = parse_metadata_from_ph(elf, meta_ph_index)
+            _, items, meta_blob, meta_file_off = parse_metadata_from_ph(
+                elf, meta_ph_index
+            )
 
             if meta_item_index < len(items):
                 it = items[meta_item_index]
                 # item_size is the third uint32 in the fixed part (offset +8 from item start)
                 abs_field_off = meta_file_off + it.start_off + 8
-                data[abs_field_off:abs_field_off + 4] = struct.pack("<I", new_size)
-                print(f"[i] Updated metadata item[{meta_item_index}] ('{it.config_name}') "
-                      f"item_size: {it.item_size} -> {new_size} "
-                      f"(at file offset 0x{abs_field_off:x})")
+                data[abs_field_off : abs_field_off + 4] = struct.pack("<I", new_size)
+                print(
+                    f"[i] Updated metadata item[{meta_item_index}] ('{it.config_name}') "
+                    f"item_size: {it.item_size} -> {new_size} "
+                    f"(at file offset 0x{abs_field_off:x})"
+                )
             else:
-                print(f"[!] meta_item_index={meta_item_index} out of range "
-                      f"(metadata has {len(items)} items); item_size not updated")
+                print(
+                    f"[!] meta_item_index={meta_item_index} out of range "
+                    f"(metadata has {len(items)} items); item_size not updated"
+                )
         except Exception as exc:
             print(f"[!] Could not update metadata item_size: {exc}")
     else:
-        print(f"[i] PH#{target_ph_index} has no corresponding metadata item (index < 2); "
-              f"item_size not updated")
+        print(
+            f"[i] PH#{target_ph_index} has no corresponding metadata item (index < 2); "
+            f"item_size not updated"
+        )
 
     # ----------------------------------------------------------
     # Replace SHA-384 hash (binary search in the whole file)
     # ----------------------------------------------------------
     pos = bytes(data).find(old_hash)
     if pos != -1:
-        print(f"[i] Found old SHA-384 at file offset 0x{pos:x}; replacing with new hash")
-        data[pos:pos + len(new_hash)] = new_hash
+        print(
+            f"[i] Found old SHA-384 at file offset 0x{pos:x}; replacing with new hash"
+        )
+        data[pos : pos + len(new_hash)] = new_hash
     else:
         print("[!] Old SHA-384 hash not found in ELF binary; hash table not updated")
 
@@ -381,34 +448,46 @@ def replace_ph(elf_path: str, target_ph_index: int, new_file: str,
         out.write(data)
     print(f"[+] Written patched ELF to '{output_file}'")
 
+
 # =========================================================
 # CLI
 # =========================================================
+
 
 def main():
     ap = argparse.ArgumentParser(
         description="Inspect and patch an XBLConfig ELF binary"
     )
     ap.add_argument("elf_file", help="Path to the XBLConfig ELF binary")
-    ap.add_argument("--meta-ph", type=int, default=1,
-                    help="Program header index that contains the XBLConfig metadata blob "
-                         "(default: 1)")
+    ap.add_argument(
+        "--meta-ph",
+        type=int,
+        default=1,
+        help="Program header index that contains the XBLConfig metadata blob "
+        "(default: 1)",
+    )
 
     sub = ap.add_subparsers(dest="command")
 
     # ---- dump (default behaviour) ----
     p_dump = sub.add_parser("dump", help="Dump all config items to individual files")
-    p_dump.add_argument("--out-dir", default=".",
-                        help="Directory to write dumped files (default: current directory)")
+    p_dump.add_argument(
+        "--out-dir",
+        default=".",
+        help="Directory to write dumped files (default: current directory)",
+    )
 
     # ---- replace ----
-    p_replace = sub.add_parser("replace", help="Replace the payload in a program header")
-    p_replace.add_argument("ph_index", type=int,
-                           help="Index of the program header whose payload to replace")
-    p_replace.add_argument("new_file",
-                           help="Path to the new payload file")
-    p_replace.add_argument("output_elf",
-                           help="Path for the patched output ELF")
+    p_replace = sub.add_parser(
+        "replace", help="Replace the payload in a program header"
+    )
+    p_replace.add_argument(
+        "ph_index",
+        type=int,
+        help="Index of the program header whose payload to replace",
+    )
+    p_replace.add_argument("new_file", help="Path to the new payload file")
+    p_replace.add_argument("output_elf", help="Path for the patched output ELF")
 
     args = ap.parse_args()
 
@@ -424,6 +503,7 @@ def main():
         # default: dump
         out_dir = getattr(args, "out_dir", ".")
         dump_from_meta(args.elf_file, out_dir, args.meta_ph)
+
 
 if __name__ == "__main__":
     main()

--- a/uefi_capsule_generation/xblconfig_parser.py
+++ b/uefi_capsule_generation/xblconfig_parser.py
@@ -7,7 +7,6 @@ import hashlib
 import io
 import os
 import struct
-import sys
 
 from dataclasses import dataclass
 from typing import List, Tuple
@@ -255,7 +254,7 @@ def dump_from_meta(elf_path: str, out_dir: str, meta_ph_index: int) -> None:
         f"Metadata (PH#{meta_ph_index}) xcfg_type='{hdr.xcfg_type}' "
         f"v{hdr.major}.{hdr.minor} entries={hdr.entries} meta_size={hdr.meta_size}"
     )
-    print(f"Dumping items -> program headers starting at index 2 (i -> PH i+2):\n")
+    print("Dumping items -> program headers starting at index 2 (i -> PH i+2):\n")
 
     for idx, it in enumerate(items):
         name = it.config_name

--- a/uefi_capsule_generation/xblconfig_parser.py
+++ b/uefi_capsule_generation/xblconfig_parser.py
@@ -344,10 +344,6 @@ def replace_ph(
     print(f"[i] New SHA-384: {new_hash.hex()}")
 
     is_64 = elf.elfclass == 64
-    endian = "<" if elf.little_endian else ">"
-    phoff = elf.header["e_phoff"]
-    phentsz = elf.header["e_phentsize"]
-    shoff = elf.header["e_shoff"]
 
     grow_size = new_size - old_size
 


### PR DESCRIPTION
- Apply ruff format across all 13 Python sources for consistent code style (quotes, whitespace, trailing commas, line length)
- Remove unused imports (pickle, stat, struct, enum.Enum, shutil, argparse, pathlib.Path, traceback, os, sys) and convert f-strings without placeholders to plain strings
- Replace bare except: clauses with except Exception: so that SystemExit and KeyboardInterrupt propagate correctly
- Use idiomatic PEP 8 singleton comparisons (is True / is not True / is None instead of == / !=)
- Remove unused local variables and fix undefined name e in an exception handler that was referencing an unbound variable
- Sort import statements with isort (stdlib first, then third-party, then local)
- Add type annotations to fix mypy --ignore-missing-imports var-annotated errors