### PR TITLE
Unify platform-specific code

### DIFF
--- a/uefi_capsule_generation/FVCreation.py
+++ b/uefi_capsule_generation/FVCreation.py
@@ -158,18 +158,6 @@ def CalcCRC32_i(buffer_b, l_i):
     return Reflect(regs_i, 32) ^ int(0xFFFFFFFF)
 
 
-def execute_command(s_command):
-    try:
-        result = subprocess.run(
-            ["cmd", "/c", s_command], capture_output=True, text=True, shell=True
-        )
-        print(result.stdout)
-        if result.stderr:
-            print(result.stderr)
-    except Exception as e:
-        print(f"Exception running command: {e}\n")
-
-
 def execute_command_linux(s_command):
     try:
         result = subprocess.run(s_command, capture_output=True, text=True, shell=True)
@@ -186,6 +174,13 @@ def _resolve_tools_dir(tool_name):
     if found:
         return os.path.dirname(found)
     return os.path.dirname(os.path.realpath(__file__))
+
+
+def _tool_path(tools_dir, name):
+    """Return the full path to an edk2 BaseTools binary, with .exe on Windows."""
+    if platform.system() == "Windows" and not name.endswith(".exe"):
+        name = name + ".exe"
+    return os.path.join(tools_dir, name)
 
 
 def regenerate_all_executables():
@@ -256,17 +251,10 @@ def generate_fv(s_output_file_name, ls_ffs, s_gen_fv, tools_dir=None):
         print(f"ERROR: Failure creating {FV_MAIN_INF_NAME} file.")
         return False
 
-    if platform.system() == "Linux":
-        if tools_dir is None:
-            tools_dir = _resolve_tools_dir("GenFv")
-        sFVCommand = (
-            f"{tools_dir}/GenFv -o {s_output_file_name} -i {FV_MAIN_INF_NAME} -v"
-        )
-        execute_command_linux(sFVCommand)
-
-    if platform.system() == "Windows":
-        sFVCommand = f"{s_gen_fv} -o {s_output_file_name} -i {FV_MAIN_INF_NAME} -v"
-        execute_command(sFVCommand)
+    if tools_dir is None:
+        tools_dir = _resolve_tools_dir("GenFv")
+    sFVCommand = f"{_tool_path(tools_dir, 'GenFv')} -o {s_output_file_name} -i {FV_MAIN_INF_NAME} -v"
+    execute_command_linux(sFVCommand)
 
     if not os.path.exists(s_output_file_name):
         bReturn = False
@@ -615,29 +603,14 @@ def generate_sys_fw_ffs_list(
 
             print(f"INFO: Creating ffs file for {raw_fwentry.InputBinary}.")
 
-            #
-            # execute GenFfs in Linux
-            #
-            if platform.system() == "Linux":
-                if tools_dir is None:
-                    tools_dir = _resolve_tools_dir("GenFfs")
-                raw_fwentry_FileGuid_uuid_bytes_obj = bytes(raw_fwentry.FileGuid)
-                raw_fwentry_FileGuid_uuid_str = str(
-                    uuid.UUID(bytes=raw_fwentry_FileGuid_uuid_bytes_obj)
-                )
-                s_command = f"{tools_dir}/GenFfs -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {raw_fwentry_FileGuid_uuid_str} -s -v -i {os.path.join(s_dir_path, raw_fwentry.InputBinary)}"
-                execute_command_linux(s_command)
-
-            #
-            # execute GenFfs in Windows
-            #
-            if platform.system() == "Windows":
-                raw_fwentry_FileGuid_uuid_bytes_obj = bytes(raw_fwentry.FileGuid)
-                raw_fwentry_FileGuid_uuid_str = str(
-                    uuid.UUID(bytes=raw_fwentry_FileGuid_uuid_bytes_obj)
-                )
-                s_command = f"{s_gen_ffs} -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {raw_fwentry_FileGuid_uuid_str} -s -v -i {os.path.join(s_dir_path, raw_fwentry.InputBinary)}"
-                execute_command(s_command)
+            if tools_dir is None:
+                tools_dir = _resolve_tools_dir("GenFfs")
+            raw_fwentry_FileGuid_uuid_bytes_obj = bytes(raw_fwentry.FileGuid)
+            raw_fwentry_FileGuid_uuid_str = str(
+                uuid.UUID(bytes=raw_fwentry_FileGuid_uuid_bytes_obj)
+            )
+            s_command = f"{_tool_path(tools_dir, 'GenFfs')} -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {raw_fwentry_FileGuid_uuid_str} -s -v -i {os.path.join(s_dir_path, raw_fwentry.InputBinary)}"
+            execute_command_linux(s_command)
 
             ls_ffs.append(s_file_name + ".ffs")
 
@@ -645,15 +618,10 @@ def generate_sys_fw_ffs_list(
         s_guid = FVC_h.GlobalStaticVariable.FILE_GUID_METADATA_GUID.strip("{}")
 
         print(f"INFO: Creating ffs file for {SYS_FW_METADATA_FILE}.")
-        if platform.system() == "Linux":
-            if tools_dir is None:
-                tools_dir = _resolve_tools_dir("GenFfs")
-            s_command = f"{tools_dir}/GenFfs -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {s_guid} -s -v -i {SYS_FW_METADATA_FILE}"
-            execute_command_linux(s_command)
-
-        if platform.system() == "Windows":
-            s_command = f"{s_gen_ffs} -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {s_guid} -s -v -i {SYS_FW_METADATA_FILE}"
-            execute_command(s_command)
+        if tools_dir is None:
+            tools_dir = _resolve_tools_dir("GenFfs")
+        s_command = f"{_tool_path(tools_dir, 'GenFfs')} -o {s_file_name}.ffs -t EFI_FV_FILETYPE_RAW -g {s_guid} -s -v -i {SYS_FW_METADATA_FILE}"
+        execute_command_linux(s_command)
 
         ls_ffs.append(s_file_name + ".ffs")
 
@@ -736,10 +704,7 @@ def The_Main(args):
     for i, arg in enumerate(args):
         if arg in ("--edk2-path", "-edk2path") and i + 1 < len(args):
             edk2_path = args[i + 1]
-            if platform.system() == "Linux":
-                tools_dir = os.path.join(edk2_path, "BaseTools", "Source", "C", "bin")
-            elif platform.system() == "Windows":
-                tools_dir = edk2_path
+            tools_dir = os.path.join(edk2_path, "BaseTools", "Source", "C", "bin")
             del args[i : i + 2]
             break
 

--- a/uefi_capsule_generation/UpdateJsonParameters.py
+++ b/uefi_capsule_generation/UpdateJsonParameters.py
@@ -197,7 +197,7 @@ def GetSysFirmwareInfo(args):
             print("Invalid system firmware version file: {0}".format(SysBinPath))
             sys.exit(1)
 
-        if platform.system() == "Linux":
+        if platform.system() in ("Linux", "Darwin"):
             SysFwExePath = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)), "SYSFW_VERSION_program.py"
             )

--- a/uefi_capsule_generation/capsule_setup.py
+++ b/uefi_capsule_generation/capsule_setup.py
@@ -24,7 +24,6 @@ import validators
 
 edk2_branch = "edk2-stable202008"
 edk2_git_repo_sync_url = "https://github.com/tianocore/edk2.git"
-edk2_windows_base_tools_url = "https://github.com/tianocore/edk2-BaseTools-win32.git"
 generate_capsule_py_sync_url = (
     "https://raw.githubusercontent.com/tianocore"
     "/edk2/ef91b07388e1c0a50c604e5350eeda98428ccea6/BaseTools/Source/Python"
@@ -167,40 +166,31 @@ def sync_and_build_edk2_linux(edk2_dir_path, c_dir):
 ###
 
 
-def print_header_sync_edk2_win(clone_dir, git_command):
-    print("\n\n\n")
-    print("Copying edk2")
-    print(
-        "--------------------------------------------------------------"
-        "------------------------------------"
-    )
-    print(f"Github URL: {edk2_windows_base_tools_url}")
-    print(f"Clone local path: {clone_dir}")
-    print(f"git clone command: {git_command}")
-    print(
-        "--------------------------------------------------------------"
-        "------------------------------------"
-    )
-    print("\n\n")
-
-
 def sync_edk2_win(clone_dir):
+    """Clone edk2 on Windows using POSIX git via MSYS2/git-for-windows."""
 
     if os.path.exists(clone_dir):
-        print("\n\nedk2  found\n\n")
-        return "edk2  found"
+        print("\n\nedk2 found\n\n")
+        return "edk2 found"
 
-    # git_command = "git clone %s %s" % (edk2_git_repo_sync_url, clone_dir)
-    git_command = "git clone %s %s" % (edk2_windows_base_tools_url, clone_dir)
-    print_header_sync_edk2_win(clone_dir, git_command)
+    print_header_sync_edk2_linux(clone_dir)
 
     if not validators.url(edk2_git_repo_sync_url):
         print(f"Invalid URL: {edk2_git_repo_sync_url}")
-        print("Terminated copying edk2")
         return f"Invalid URL: {edk2_git_repo_sync_url}"
 
     try:
-        subprocess.run("cmd /c " + git_command, check=True)
+        subprocess.run(
+            [
+                "git",
+                "clone",
+                "--depth",
+                "1",
+                edk2_git_repo_sync_url,
+                clone_dir,
+            ],
+            check=True,
+        )
         print("\n\n\nEdk2 cloning complete\n\n")
     except Exception:
         print("\n", traceback.format_exc())
@@ -210,61 +200,23 @@ def sync_edk2_win(clone_dir):
     return True
 
 
-def update_edk2_submodules_win(edk2_dir_path):
-    try:
-        os.chdir(edk2_dir_path)
-        subprocess.run(["git", "submodule", "update", "--init"], check=True)
-    except Exception:
-        print(
-            "Failed executing: subprocess.run("
-            "['git', 'submodule', 'update', '--init'], check=True)"
-        )
-        print(traceback.format_exc())
-        return False
-    return True
-
-
-def build_edk2(edk2_dir_path):
-
-    try:
-        os.chdir(edk2_dir_path)
-        subprocess.run(["edksetup.bat", "Rebuild"], check=True)
-    except Exception:
-        print(
-            "Failed executing: subprocess.run(['edksetup.bat', 'Rebuild'], check=True)"
-        )
-        print(traceback.format_exc())
-        return "Failed to build edk2"
-    return True
-
-
-def build_edk2_win(edk2_dir_path, full_build):
-
-    base_dir = os.path.dirname(os.path.abspath(__file__))
-    os.chdir(edk2_dir_path)
-
-    if full_build:
-        if not update_edk2_submodules_win(edk2_dir_path):
-            os.chdir(base_dir)
-            return "Failed to sync submodules"
-    else:
-        print("\n\nFull build not enabled, skipping submodules sync\n\n")
-
-    if not build_edk2(edk2_dir_path):
-        os.chdir(base_dir)
-        return "Failed to build Edk2"
-
-    os.chdir(base_dir)
-    print("\n\nEdk2 build complete\n\n\n")
-    return True
-
-
 def sync_and_build_edk2_win(clone_dir, full_build):
+    """Sync and build edk2 BaseTools C on Windows via MSYS2 (make + gcc)."""
 
     if platform.system() == "Windows":
         edk2_get_repo_sync_stats = sync_edk2_win(clone_dir)
         if edk2_get_repo_sync_stats is not True:
             return edk2_get_repo_sync_stats
+
+        if init_brotli_submodule(clone_dir) is not True:
+            return "Failed to init brotli submodule"
+
+        c_dir = os.path.join(clone_dir, "BaseTools", "Source", "C")
+        edk2_build_stats = run_make_command_linux(c_dir)
+        if edk2_build_stats is not True:
+            return edk2_build_stats
+
+    return True
 
 
 ###
@@ -616,8 +568,9 @@ def Main(args):
             base_dir_abs, "GenerateCapsule.py"
         )
         edk2_sync_local_path_abs = os.path.join(base_dir_abs, "edk2")
-        genffs_sync_path_win_abs = os.path.join(edk2_sync_local_path_abs, "GenFfs.exe")
-        genfv_sync_path_win_abs = os.path.join(edk2_sync_local_path_abs, "GenFv.exe")
+        c_dir = os.path.join(edk2_sync_local_path_abs, "BaseTools", "Source", "C")
+        genffs_sync_path_win_abs = os.path.join(c_dir, "bin", "GenFfs.exe")
+        genfv_sync_path_win_abs = os.path.join(c_dir, "bin", "GenFv.exe")
         genffs_local_path_abs = os.path.join(base_dir_abs, "GenFfs.exe")
         genfv_local_path_abs = os.path.join(base_dir_abs, "GenFv.exe")
         common_dir_local_sync_path_abs = os.path.join(base_dir_abs, "Common")

--- a/uefi_capsule_generation/capsule_setup.py
+++ b/uefi_capsule_generation/capsule_setup.py
@@ -146,7 +146,7 @@ def sync_edk2_linux(edk2_git_repo_sync_url, edk2_dir_path):
 
 def sync_and_build_edk2_linux(edk2_dir_path, c_dir):
 
-    if platform.system() == "Linux":
+    if platform.system() in ("Linux", "Darwin"):
         edk2_get_repo_sync_stats = sync_edk2_linux(
             edk2_git_repo_sync_url, edk2_dir_path
         )
@@ -235,7 +235,7 @@ def force_delete_folder(folder_path):
             print(f"Failed to delete Dir {folder_path}")
             print(e)
 
-    if platform.system() == "Linux":
+    if platform.system() in ("Linux", "Darwin"):
         try:
             shutil.rmtree(folder_path)
             print(f"Dir deleted successfully: {folder_path}")
@@ -516,7 +516,7 @@ def print_stats(
 
 def Main(args):
 
-    if platform.system() == "Linux":
+    if platform.system() in ("Linux", "Darwin"):
         base_dir_abs = os.path.dirname(os.path.abspath(__file__))
         generate_capsule_py_file_path_abs = os.path.join(
             base_dir_abs, "GenerateCapsule.py"


### PR DESCRIPTION
Linux, macOS, and Windows currently take three different code paths for
the edk2 build and the GenFfs/GenFv invocation. macOS isn't supported
at all (every `platform.system() == "Linux"` guard skips it), Windows
uses a separate pre-built repo and `edksetup.bat`, and FVCreation.py
duplicates the tool invocation under `cmd /c`. The divergence makes
every fix or refactor a three-way change.

What changed:

1. **MSYS2 build on Windows** - shallow-clone upstream `edk2` and build
   `BaseTools/Source/C` via `make`, reusing the Linux helpers.
2. **Unify GenFfs/GenFv** - one call site for both OSes, with a small
   `_tool_path()` helper that appends `.exe` on Windows.
3. **macOS (Darwin) support** - widen `Linux`-only guards to
   `("Linux", "Darwin")`.