### PR TITLE
ci: pin edk2, mingw-w64 toolchain and linters to fix CI breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,23 @@ jobs:
             mingw-w64-x86_64-curl
             mingw-w64-x86_64-dtc
 
+      - name: Pin mingw-w64 toolchain (Windows)
+        if: runner.os == 'Windows'
+        # mingw-w64 r179 removed the noreturn attribute from _assert/
+        # _wassert (commit ecf2328a32), so gcc 16 can no longer prune
+        # the assert-guarded out-of-range path in edk2 BaseTools
+        # CommonLib.c StrToIpv6Address and fails the -Werror build with
+        # stringop-overflow. Pin headers/crt/gcc to the versions from
+        # the last green run (2026-06-24) until the edk2 BaseTools
+        # dependency is dropped.
+        run: |
+          pacman -U --noconfirm \
+            https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-headers-14.0.0.r98.g19f5121a2-1-any.pkg.tar.zst \
+            https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-crt-14.0.0.r98.g19f5121a2-1-any.pkg.tar.zst \
+            https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-16.1.0-5-any.pkg.tar.zst \
+            https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-16.1.0-5-any.pkg.tar.zst
+        shell: msys2 {0}
+
       - name: Cache downloaded boot binaries
         uses: actions/cache@v4
         with:

--- a/uefi_capsule_generation/pyproject.toml
+++ b/uefi_capsule_generation/pyproject.toml
@@ -17,8 +17,8 @@ pyelftools = "*"
 pylibfdt = "*"
 
 [tool.poetry.group.dev.dependencies]
-ruff = "*"
-mypy = "*"
+ruff = "0.15.16"
+mypy = "1.19.1"
 types-requests = "*"
 
 [tool.poetry.scripts]

--- a/uefi_capsule_generation/src/qcom_capsule_tool/capsule_setup.py
+++ b/uefi_capsule_generation/src/qcom_capsule_tool/capsule_setup.py
@@ -31,6 +31,10 @@ def _is_http_url(url):
 
 edk2_branch = "edk2-stable202008"
 edk2_git_repo_sync_url = "https://github.com/tianocore/edk2.git"
+# BaseTools is built from source with -Werror, so an unpinned master
+# clone breaks whenever a new edk2/toolchain combination introduces a
+# warning. Pin to a stable release.
+edk2_pin_tag = "edk2-stable202605"
 generate_capsule_py_sync_url = (
     "https://raw.githubusercontent.com/tianocore"
     "/edk2/ef91b07388e1c0a50c604e5350eeda98428ccea6/BaseTools/Source/Python"
@@ -41,6 +45,23 @@ basetools_common_sync_url = (
     "edk2-stable202008/BaseTools/Source/Python/Common"
 )
 BROTLI_SUBMODULE_PATH = "BaseTools/Source/C/BrotliCompress/brotli"
+
+
+def _clone_edk2_pinned(edk2_dir_path):
+    """Shallow-clone edk2 at the pinned stable release tag."""
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            edk2_pin_tag,
+            edk2_git_repo_sync_url,
+            edk2_dir_path,
+        ],
+        check=True,
+    )
 
 
 ###
@@ -150,18 +171,8 @@ def sync_edk2_linux(edk2_git_repo_sync_url, edk2_dir_path):
     print_header_sync_edk2_linux(edk2_dir_path)
 
     try:
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                "--depth",
-                "1",
-                edk2_git_repo_sync_url,
-                edk2_dir_path,
-            ],
-            check=True,
-        )
-        print(f"Repository cloned into {edk2_dir_path}")
+        _clone_edk2_pinned(edk2_dir_path)
+        print(f"Repository cloned into {edk2_dir_path} at {edk2_pin_tag}")
 
     except subprocess.CalledProcessError as e:
         print(f"Error cloning repository: {e}")
@@ -210,18 +221,8 @@ def sync_edk2_win(clone_dir):
         return f"Invalid URL: {edk2_git_repo_sync_url}"
 
     try:
-        subprocess.run(
-            [
-                "git",
-                "clone",
-                "--depth",
-                "1",
-                edk2_git_repo_sync_url,
-                clone_dir,
-            ],
-            check=True,
-        )
-        print("\n\n\nEdk2 cloning complete\n\n")
+        _clone_edk2_pinned(clone_dir)
+        print(f"\n\n\nEdk2 cloning complete at {edk2_pin_tag}\n\n")
     except Exception:
         print("\n", traceback.format_exc())
         print("\nFailed to sync edk2 from github\n\n")


### PR DESCRIPTION
Windows CI has been failing since July because a mingw-w64 update (r179) removed the `noreturn` attribute from `_assert`/`_wassert`, which makes gcc 16 flag an assert-guarded path in edk2 `BaseTools` `CommonLib.c` as stringop-overflow and fail the -Werror build. 

Independently, the lint job has been red since ruff 0.15.17 introduced stricter default rules that flag pre-existing code. Since CI builds against unpinned moving targets (edk2 master, latest MSYS2 packages, floating dev dependencies), any of them can break us without a change on our side - so pin all three:
* edk2 to the edk2-stable202605 release
* the mingw-w64 headers/crt/gcc packages to the versions from the last green run
* ruff/mypy to their last known-good versions.